### PR TITLE
Transpose

### DIFF
--- a/src/Gaius.jl
+++ b/src/Gaius.jl
@@ -1,14 +1,16 @@
 module Gaius
 
-using LoopVectorization: @avx, VectorizationBase.PackedStridedPointer, VectorizationBase.SparseStridedPointer, VectorizationBase.gep, VectorizationBase.vload, VectorizationBase.vstore!, VectorizationBase.REGISTER_SIZE
+using LoopVectorization: @avx, VectorizationBase.AbstractStridedPointer, VectorizationBase.gesp, VectorizationBase.vload, VectorizationBase.vstore!, VectorizationBase.AVX512F
 import LoopVectorization: @avx, VectorizationBase.stridedpointer
 using StructArrays: StructArray
 using LinearAlgebra: LinearAlgebra
 
 
-const DEFAULT_BLOCK_SIZE = REGISTER_SIZE == 64 ? 64 : 32
+const DEFAULT_BLOCK_SIZE = AVX512F ? 96 : 64
 const Eltypes  = Union{Float64, Float32, Int64, Int32, Int16}
-const MatTypes{T <: Eltypes} = Union{Matrix{T}, SubArray{T, 2, <: Array}}
+const MatTypesC{T <: Eltypes} = Union{Matrix{T}, SubArray{T, 2, <: Array}} # C for Column Major
+const MatTypesR{T <: Eltypes} = Union{LinearAlgebra.Adjoint{T,<:MatTypesC{T}}, LinearAlgebra.Transpose{T,<:MatTypesC{T}}} # R for Row Major
+const MatTypes{T <: Eltypes} = Union{MatTypesC{T}, MatTypesR{T}}
 
 # Note this does not support changing the number of threads at runtime
 macro _spawn(ex)

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -16,17 +16,16 @@ function (*)(A::MatTypes, B::MatTypes)
     C
 end
 
+choose_block_size(C::AbstractMatrix, ::Nothing) = size(C, 1) >= (3DEFAULT_BLOCK_SIZE) >>> 1 ? DEFAULT_BLOCK_SIZE : 32
+choose_block_size(::Any, block_size::Integer) = block_size
+
 function mul!(C::MatTypes{T}, A::MatTypes{T}, B::MatTypes{T};
               block_size = nothing, sizecheck=true) where {T <: Eltypes}
     sizecheck && check_compatible_sizes(C, A, B)
-    if isnothing(block_size)
-        if 2size(C, 1) >= 3DEFAULT_BLOCK_SIZE
-            block_size = DEFAULT_BLOCK_SIZE
-        else
-            block_size = 32
-        end
-    end
-    GC.@preserve C A B _mul!(PtrMatrix(C), PtrMatrix(A), PtrMatrix(B), block_size)
+
+    _block_size = choose_block_size(C, block_size)
+
+    GC.@preserve C A B _mul!(PtrMatrix(C), PtrMatrix(A), PtrMatrix(B), _block_size)
     C
 end
 
@@ -41,13 +40,7 @@ function mul!(C::StructArray{Complex{T}, 2}, A::StructArray{Complex{T}, 2}, B::S
               block_size = DEFAULT_BLOCK_SIZE, sizecheck=true) where {T <: Eltypes}
     sizecheck && check_compatible_sizes(C, A, B)
     
-    if isnothing(block_size)
-        if size(C, 1) >= 72
-            block_size = 48
-        else
-            block_size = 32
-        end
-    end
+    _block_size = choose_block_size(C, block_size)
     
     GC.@preserve C A B begin
         Cre, Cim = PtrMatrix(C.re), PtrMatrix(C.im)
@@ -56,10 +49,10 @@ function mul!(C::StructArray{Complex{T}, 2}, A::StructArray{Complex{T}, 2}, B::S
         # Cre, Cim = C.re, C.im
         # Are, Aim = A.re, A.im
         # Bre, Bim = B.re, B.im
-        _mul!(    Cre, Are, Bre,  block_size)          # C.re = A.re * B.re
-        _mul_add!(Cre, Aim, Bim,  block_size, Val(-1)) # C.re = C.re - A.im * B.im
-        _mul!(    Cim, Are, Bim,  block_size)          # C.im = A.re * B.im
-        _mul_add!(Cim, Aim, Bre,  block_size)          # C.im = C.im + A.im * B.re
+        _mul!(    Cre, Are, Bre, _block_size)          # C.re = A.re * B.re
+        _mul_add!(Cre, Aim, Bim, _block_size, Val(-1)) # C.re = C.re - A.im * B.im
+        _mul!(    Cim, Are, Bim, _block_size)          # C.im = A.re * B.im
+        _mul_add!(Cim, Aim, Bre, _block_size)          # C.im = C.im + A.im * B.re
     end
     C
 end

--- a/src/pointermatrix.jl
+++ b/src/pointermatrix.jl
@@ -1,38 +1,30 @@
-abstract type AbstractPointerMatrix{T} <: AbstractMatrix{T} end
-struct PointerMatrix{T} <: AbstractPointerMatrix{T}
-    ptr::Ptr{T}
-    size::NTuple{2,Int}
-    stride2::Int
-end
-struct SparseStridePointerMatrix{T} <: AbstractPointerMatrix{T}
-    ptr::Ptr{T}
+
+struct PointerMatrix{T,P <: AbstractStridedPointer} <: AbstractMatrix{T}
+    ptr::P
     size::Tuple{Int,Int}
-    strides::Tuple{Int,Int}
+    PointerMatrix(ptr::P, size::Tuple{Int,Int}) where {T, P <: AbstractStridedPointer{T}} = new{T,P}(ptr, size)
 end
-@inline PtrMatrix(A::MatTypes) = PointerMatrix(pointer(A), size(A), stride(A, 2))
-@inline PtrMatrix(A::SubArray{T,2,<:Array{T,<:Any},<:Tuple{Int64,Vararg}}) where {T <: Eltypes} = SparseStridePointerMatrix(pointer(A), size(A), strides(A))
-@inline Base.pointer(A::AbstractPointerMatrix) = A.ptr
-@inline Base.size(A::AbstractPointerMatrix) = A.size
-@inline Base.strides(A::PointerMatrix) = (1, A.stride2)
-@inline Base.strides(A::SparseStridePointerMatrix) = A.strides
-@inline stridedpointer(A::PointerMatrix) = PackedStridedPointer(A.ptr, (A.stride2,))
-@inline stridedpointer(A::SparseStridePointerMatrix) = SparseStridedPointer(A.ptr, A.strides)
-@inline Base.maybeview(A::PointerMatrix, r::UnitRange, c::UnitRange) = PointerMatrix(gep(pointer(A), first(r) - 1 + (first(c) - 1)*A.stride2), (length(r), length(c)), A.stride2)
-@inline Base.maybeview(A::SparseStridePointerMatrix, r::UnitRange, c::UnitRange) = @inbounds SparseStridePointerMatrix(gep(pointer(A), (first(r) - 1)*A.strides[1] + (first(c) - 1)*A.strides[2]), (length(r), length(c)), A.strides)
+@inline PtrMatrix(A::AbstractMatrix) = PointerMatrix(stridedpointer(A), size(A))
+@inline Base.pointer(A::PointerMatrix) = pointer(A.ptr)
+@inline Base.size(A::PointerMatrix) = A.size
+@inline Base.strides(A::PointerMatrix) = strides(A.ptr)
+@inline stridedpointer(A::PointerMatrix) = A.ptr
+
+@inline Base.maybeview(A::PointerMatrix, r::UnitRange, c::UnitRange) = PointerMatrix(gesp(A.ptr, (first(r) - 1, (first(c) - 1))), (length(r), length(c)))
 # getindex is important for the sake of printing the AbstractPointerMatrix. If we call something a Matrix, it's nice to support the interface if possible.
-Base.@propagate_inbounds function Base.getindex(A::AbstractPointerMatrix, i::Integer, j::Integer)
+Base.@propagate_inbounds function Base.getindex(A::PointerMatrix, i::Integer, j::Integer)
     @boundscheck begin
         M, N = size(A)
         (M < i || N < j) && throw(BoundsError(A, (i,j)))
     end
     vload(stridedpointer(A), (i-1, j-1))
 end
-Base.@propagate_inbounds function Base.getindex(A::AbstractPointerMatrix, v, i::Integer, j::Integer)
+Base.@propagate_inbounds function Base.getindex(A::PointerMatrix, v, i::Integer, j::Integer)
     @boundscheck begin
         M, N = size(A)
         (M < i || N < j) && throw(BoundsError(A, (i,j)))
     end
     vstore!(stridedpointer(A), v, (i-1, j-1))
 end
-Base.IndexStyle(::Type{<:AbstractPointerMatrix}) = IndexCartesian()
+Base.IndexStyle(::Type{<:PointerMatrix}) = IndexCartesian()
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,9 +37,14 @@ end
             C2 = zeros(n, m)
             A  = randn(n, k)
             B  = randn(k, m)
-           
+            At = copy(A')
+            Bt = copy(B')
+
             @test Gaius.mul!(C1, A, B) ≈ mul!(C2, A, B)
             @test Gaius.:(*)(A, B) ≈ C1
+            fill!(C1, NaN); @test Gaius.mul!(C1, At', B)   ≈ C2
+            fill!(C1, NaN); @test Gaius.mul!(C1, A,   Bt') ≈ C2
+            fill!(C1, NaN); @test Gaius.mul!(C1, At', Bt') ≈ C2
         end
     end
     for sz ∈ [10, 50, 100, 200, 400, 1000]
@@ -49,9 +54,14 @@ end
             C2 = zeros(n, m)
             A  = randn(n, k)
             B  = randn(k, m)
+            At = copy(A')
+            Bt = copy(B')
            
             @test Gaius.mul!(C1, A, B) ≈ mul!(C2, A, B)
             @test Gaius.:(*)(A, B) ≈ C1
+            fill!(C1, NaN); @test Gaius.mul!(C1, At', B)   ≈ C2
+            fill!(C1, NaN); @test Gaius.mul!(C1, A,   Bt') ≈ C2
+            fill!(C1, NaN); @test Gaius.mul!(C1, At', Bt') ≈ C2
         end
     end
 end
@@ -64,9 +74,14 @@ end
             C2 = zeros(Float32, n, m)
             A  = randn(Float32, n, k)
             B  = randn(Float32, k, m)
+            At = copy(A')
+            Bt = copy(B')
            
             @test Gaius.mul!(C1, A, B) ≈ mul!(C2, A, B)
             @test Gaius.:(*)(A, B) ≈ C1
+            fill!(C1, NaN32); @test Gaius.mul!(C1, At', B)   ≈ C2
+            fill!(C1, NaN32); @test Gaius.mul!(C1, A,   Bt') ≈ C2
+            fill!(C1, NaN32); @test Gaius.mul!(C1, At', Bt') ≈ C2
         end
     end
 end
@@ -80,9 +95,14 @@ end
             C2 = zeros(Int, n, m)
             A  = rand(-100:100, n, k)
             B  = rand(-100:100, k, m)
+            At = copy(A')
+            Bt = copy(B')
            
             @test Gaius.mul!(C1, A, B) ≈ mul!(C2, A, B)
             @test Gaius.:(*)(A, B) ≈ C1
+            fill!(C1, typemax(Int64)); @test Gaius.mul!(C1, At', B)   ≈ C2
+            fill!(C1, typemax(Int64)); @test Gaius.mul!(C1, A,   Bt') ≈ C2
+            fill!(C1, typemax(Int64)); @test Gaius.mul!(C1, At', Bt') ≈ C2
         end
     end
 end
@@ -96,9 +116,14 @@ end
             C2 = zeros(Int32, n, m)
             A  = rand(Int32.(-100:100), n, k)
             B  = rand(Int32.(-100:100), k, m)
-           
+            At = copy(A')
+            Bt = copy(B')
+
             @test Gaius.mul!(C1, A, B) ≈ mul!(C2, A, B)
             @test Gaius.:(*)(A, B) ≈ C1
+            fill!(C1, typemax(Int32)); @test Gaius.mul!(C1, At', B)   ≈ C2
+            fill!(C1, typemax(Int32)); @test Gaius.mul!(C1, A,   Bt') ≈ C2
+            fill!(C1, typemax(Int32)); @test Gaius.mul!(C1, At', Bt') ≈ C2
         end
     end
 end


### PR DESCRIPTION
32 additions and 42 deletions, for a net of 10 fewer lines of code, adds support for transposed matrices.
```julia
julia> using Gaius, LinearAlgebra, BenchmarkTools, LoopVectorization
[ Info: Precompiling Gaius [bffe22d1-cb55-4f4e-ac2c-f4dd4bf58912]

julia> M = 1000
1000

julia> A = rand(M, M); B = rand(M, M); C1 = similar(A); C2 = similar(A);

julia> const blocked_mul! = Gaius.mul!
mul! (generic function with 3 methods)

julia> @benchmark blocked_mul!($C1, $A, $B)
BenchmarkTools.Trial:
  memory estimate:  233.30 KiB
  allocs estimate:  1851
  --------------
  minimum time:     2.340 ms (0.00% GC)
  median time:      2.823 ms (0.00% GC)
  mean time:        2.870 ms (0.87% GC)
  maximum time:     11.502 ms (76.19% GC)
  --------------
  samples:          1738
  evals/sample:     1

julia> @benchmark mul!($C2, $A, $B)
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.376 ms (0.00% GC)
  median time:      2.123 ms (0.00% GC)
  mean time:        2.135 ms (0.00% GC)
  maximum time:     2.588 ms (0.00% GC)
  --------------
  samples:          2336
  evals/sample:     1

julia> C1 ≈ C2
true

julia> @benchmark blocked_mul!($C1, $A, $B')
BenchmarkTools.Trial:
  memory estimate:  233.34 KiB
  allocs estimate:  1854
  --------------
  minimum time:     2.309 ms (0.00% GC)
  median time:      2.748 ms (0.00% GC)
  mean time:        2.812 ms (0.92% GC)
  maximum time:     13.181 ms (78.75% GC)
  --------------
  samples:          1774
  evals/sample:     1

julia> @benchmark mul!($C2, $A, $B')
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.380 ms (0.00% GC)
  median time:      2.239 ms (0.00% GC)
  mean time:        2.191 ms (0.00% GC)
  maximum time:     2.468 ms (0.00% GC)
  --------------
  samples:          2276
  evals/sample:     1

julia> C1 ≈ C2
true

julia> @benchmark blocked_mul!($C1, $A', $B)
BenchmarkTools.Trial:
  memory estimate:  233.39 KiB
  allocs estimate:  1857
  --------------
  minimum time:     2.903 ms (0.00% GC)
  median time:      3.296 ms (0.00% GC)
  mean time:        3.351 ms (0.69% GC)
  maximum time:     12.269 ms (70.48% GC)
  --------------
  samples:          1490
  evals/sample:     1

julia> @benchmark mul!($C2, $A', $B)
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.355 ms (0.00% GC)
  median time:      2.227 ms (0.00% GC)
  mean time:        2.152 ms (0.00% GC)
  maximum time:     2.638 ms (0.00% GC)
  --------------
  samples:          2319
  evals/sample:     1

julia> C1 ≈ C2
true

julia> @benchmark blocked_mul!($C1, $A', $B')
BenchmarkTools.Trial:
  memory estimate:  233.38 KiB
  allocs estimate:  1856
  --------------
  minimum time:     2.139 ms (0.00% GC)
  median time:      2.339 ms (0.00% GC)
  mean time:        2.394 ms (1.10% GC)
  maximum time:     13.464 ms (80.25% GC)
  --------------
  samples:          2084
  evals/sample:     1

julia> @benchmark mul!($C2, $A', $B')
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.372 ms (0.00% GC)
  median time:      2.080 ms (0.00% GC)
  mean time:        2.069 ms (0.00% GC)
  maximum time:     2.571 ms (0.00% GC)
  --------------
  samples:          2412
  evals/sample:     1

julia> C1 ≈ C2
true
```

It may be better to eventually special case `C = A' * B`.
If / when packing is added, the packing process could transpose it.