### PR TITLE
Fix name for add_gemm_kernel!()

### DIFF
--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -104,7 +104,7 @@ function add_gemm_kernel!(u::CoVecTypes, v::CoVecTypes, A::MatTypes)
     end
 end
 
-function add_gemm_kernel(u::CoVecTypes, v::CoVecTypes, A::MatTypes, ::Val{-1})
+function add_gemm_kernel!(u::CoVecTypes, v::CoVecTypes, A::MatTypes, ::Val{-1})
     @avx for m ∈ 1:size(A, 2)
         uₘ = zero(eltype(u))
         for k ∈ 1:size(A, 1)


### PR DESCRIPTION
Should it be `add_gemm_kernel!()` rather than `add_gemm_kernel()`?