### PR TITLE
README: Only mention Tullio.jl and Octavian.jl

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Gaius is *not* stable or well tested. Only use it if you're adventurous.
 
 Note: Gaius is not actively maintained and I do not anticipate doing further
 work on it. There are other, more promising projects that may result in a
-scalable, multi-threaded pure Julia BLAS library such as
-[Tullio.jl](https://github.com/mcabbott/Tullio.jl) and
-[PaddedMatrices.jl](https://github.com/chriselrod/PaddedMatrices.jl).
+scalable, multi-threaded pure Julia BLAS library such as:
+1. [Tullio.jl](https://github.com/mcabbott/Tullio.jl)
+2. [Octavian.jl](https://github.com/JuliaLinearAlgebra/Octavian.jl)
 
 However, you may find this library useful as a relatively simple playground
 for learning about the implementation of linear algebra routines.


### PR DESCRIPTION
If I understand correctly, in the future, PaddedMatrices.jl will not have a matmul implementation. (And neither will StrideArrays.jl.)

So the only libraries that need to be listed are:
1. Tullio.jl
2. Gaius.jl
3. Octavian.jl