### PR TITLE
Two-phase recursion and even more balanced DAG

### DIFF
--- a/src/block_operations.jl
+++ b/src/block_operations.jl
@@ -1,12 +1,9 @@
 @inline function block_mat_mat_mul!(::Multithreaded, C, A, B, sz)
-    #=
     mᵣ, nᵣ = LoopVectorization.matmul_params()
     mstep = mᵣ * LoopVectorization.pick_vector_width(eltype(A))
     m1 = min(max(sz, mstep * div(size(A, 1), 2mstep, RoundNearest)), size(A, 1) - sz)
     n1 = min(max(sz, nᵣ * div(size(B, 2), 2nᵣ, RoundNearest)), size(B, 2) - sz)
     k1 = min(max(sz, div(size(A, 2), 2, RoundNearest)), size(A, 2) - sz)
-    =#
-    m1 = n1 = k1 = sz
     @inbounds @views begin
         C11 = C[1:m1,     1:n1]; C12 = C[1:m1,     n1+1:end]
         C21 = C[m1+1:end, 1:n1]; C22 = C[m1+1:end, n1+1:end]
@@ -251,14 +248,11 @@ function block_covec_vec_mul!(threading::Threading, C::VecTypes, A, B::VecTypes,
 end
 
 @inline function block_mat_mat_mul_add!(::Multithreaded, C, A, B, sz, ::Val{factor} = Val(1)) where {factor}
-    #=
     mᵣ, nᵣ = LoopVectorization.matmul_params()
     mstep = mᵣ * LoopVectorization.pick_vector_width(eltype(A))
     m1 = min(max(sz, mstep * div(size(A, 1), 2mstep, RoundNearest)), size(A, 1) - sz)
     n1 = min(max(sz, nᵣ * div(size(B, 2), 2nᵣ, RoundNearest)), size(B, 2) - sz)
     k1 = min(max(sz, div(size(A, 2), 2, RoundNearest)), size(A, 2) - sz)
-    =#
-    m1 = n1 = k1 = sz
     @inbounds @views begin
         C11 = C[1:m1,     1:n1]; C12 = C[1:m1,     n1+1:end]
         C21 = C[m1+1:end, 1:n1]; C22 = C[m1+1:end, n1+1:end]
@@ -428,13 +422,10 @@ function block_covec_mat_mul_add!(::Singlethreaded, C, A, B, sz, ::Val{factor} =
 end
 
 function block_vec_covec_mul_add!(::Multithreaded, C, A, B, sz, ::Val{factor} = Val(1)) where {factor}
-    #=
     mᵣ, nᵣ = LoopVectorization.matmul_params()
     mstep = mᵣ * LoopVectorization.pick_vector_width(eltype(A))
     m1 = min(max(sz, mstep * div(size(A, 1), 2mstep, RoundNearest)), size(A, 1) - sz)
     n1 = min(max(sz, nᵣ * div(size(B, 2), 2nᵣ, RoundNearest)), size(B, 2) - sz)
-    =#
-    m1 = n1 = sz
     @inbounds @views begin
         C11 = C[1:m1,     1:n1]; C12 = C[1:m1,     n1+1:end]
         C21 = C[m1+1:end, 1:n1]; C22 = C[m1+1:end, n1+1:end]

--- a/src/block_operations.jl
+++ b/src/block_operations.jl
@@ -1,4 +1,6 @@
-@inline function block_mat_mat_mul!(::Multithreaded, C, A, B, sz)
+@inline function block_mat_mat_mul!(multithreaded::Multithreaded, C, A, B, sz)
+    use_singlethread(multithreaded, C, A, B) &&
+        return block_mat_mat_mul!(singlethreaded, C, A, B, sz)
     mᵣ, nᵣ = LoopVectorization.matmul_params()
     mstep = mᵣ * LoopVectorization.pick_vector_width(eltype(A))
     m1 = min(max(sz, mstep * div(size(A, 1), 2mstep, RoundNearest)), size(A, 1) - sz)
@@ -16,8 +18,7 @@
     end
     @sync begin
         Threads.@spawn begin
-            #_mul!(multithreaded,     C11, A11, B11, sz)
-            gemm_kernel!(C11, A11, B11)
+            _mul!(multithreaded,     C11, A11, B11, sz)
             _mul_add!(multithreaded, C11, A12, B21, sz)
         end
         Threads.@spawn begin
@@ -55,7 +56,9 @@ end
     _mul_add!(singlethreaded, C22, A22, B22, sz)
 end
 
-function block_mat_vec_mul!(::Multithreaded, C, A, B, sz)
+function block_mat_vec_mul!(multithreaded::Multithreaded, C, A, B, sz)
+    use_singlethread(multithreaded, C, A, B) &&
+        return block_mat_vec_mul!(singlethreaded, C, A, B, sz)
     mstep = LoopVectorization.pick_vector_width(eltype(A))
     m1 = min(max(sz, mstep * div(size(A, 1), 2mstep, RoundNearest)), size(A, 1) - sz)
     k1 = min(max(sz, div(size(A, 2), 2, RoundNearest)), size(A, 2) - sz)
@@ -71,8 +74,7 @@ function block_mat_vec_mul!(::Multithreaded, C, A, B, sz)
     end
     @sync begin
         Threads.@spawn begin
-            #_mul!(multithreaded,     C11, A11, B11, sz)
-            gemm_kernel!(C11, A11, B11)
+            _mul!(multithreaded,     C11, A11, B11, sz)
             _mul_add!(multithreaded, C11, A12, B21, sz)
         end
         _mul!(multithreaded,     C21, A21, B11, sz)
@@ -98,7 +100,9 @@ function block_mat_vec_mul!(::Singlethreaded, C, A, B, sz)
     _mul_add!(singlethreaded, C21, A22, B21, sz)
 end
 
-function block_mat_vec_mul!(::Multithreaded, C::VecTypes, A, B::VecTypes, sz)
+function block_mat_vec_mul!(multithreaded::Multithreaded, C::VecTypes, A, B::VecTypes, sz)
+    use_singlethread(multithreaded, C, A, B) &&
+        return block_mat_vec_mul!(singlethreaded, C, A, B, sz)
     mstep = LoopVectorization.pick_vector_width(eltype(A))
     m1 = min(max(sz, mstep * div(size(A, 1), 2mstep, RoundNearest)), size(A, 1) - sz)
     k1 = min(max(sz, div(size(A, 2), 2, RoundNearest)), size(A, 2) - sz)
@@ -114,7 +118,7 @@ function block_mat_vec_mul!(::Multithreaded, C::VecTypes, A, B::VecTypes, sz)
     end
     @sync begin
         Threads.@spawn begin
-            gemm_kernel!(C11, A11, B11)
+            _mul!(multithreaded,     C11, A11, B11, sz)
             _mul_add!(multithreaded, C11, A12, B21, sz)
         end
         _mul!(multithreaded,     C21, A21, B11, sz)
@@ -139,7 +143,9 @@ function block_mat_vec_mul!(::Singlethreaded, C::VecTypes, A, B::VecTypes, sz)
     _mul_add!(singlethreaded, C21, A22, B21, sz)
 end
 
-function block_covec_mat_mul!(::Multithreaded, C, A, B, sz)
+function block_covec_mat_mul!(multithreaded::Multithreaded, C, A, B, sz)
+    use_singlethread(multithreaded, C, A, B) &&
+        return block_covec_mat_mul!(singlethreaded, C, A, B, sz)
     nstep = LoopVectorization.pick_vector_width(eltype(B))
     n1 = min(max(sz, nstep * div(size(B, 2), 2nstep, RoundNearest)), size(B, 2) - sz)
     k1 = min(max(sz, div(size(A, 2), 2, RoundNearest)), size(A, 2) - sz)
@@ -153,8 +159,7 @@ function block_covec_mat_mul!(::Multithreaded, C, A, B, sz)
     end
     @sync begin
         Threads.@spawn begin
-            #_mul!(multithreaded,     C11, A11, B11, sz)
-            gemm_kernel!(C11, A11, B11)
+            _mul!(multithreaded,     C11, A11, B11, sz)
             _mul_add!(multithreaded, C11, A12, B21, sz)
         end
         _mul!(multithreaded,     C12, A11, B12, sz)
@@ -178,7 +183,9 @@ function block_covec_mat_mul!(::Singlethreaded, C, A, B, sz)
     _mul_add!(singlethreaded, C12, A12, B22, sz)
 end
 
-function block_vec_covec_mul!(::Multithreaded, C, A, B, sz)
+function block_vec_covec_mul!(multithreaded::Multithreaded, C, A, B, sz)
+    use_singlethread(multithreaded, C, A, B) &&
+        return block_vec_covec_mul!(singlethreaded, C, A, B, sz)
     mᵣ, nᵣ = LoopVectorization.matmul_params()
     mstep = mᵣ * LoopVectorization.pick_vector_width(eltype(A))
     m1 = min(max(sz, mstep * div(size(A, 1), 2mstep, RoundNearest)), size(A, 1) - sz)
@@ -194,8 +201,7 @@ function block_vec_covec_mul!(::Multithreaded, C, A, B, sz)
     end
     @sync begin
         Threads.@spawn begin
-            #_mul!(multithreaded,     C11, A11, B11, sz)
-            gemm_kernel!(C11, A11, B11)
+            _mul!(multithreaded, C11, A11, B11, sz)
         end
         Threads.@spawn begin
             _mul!(multithreaded, C12, A11, B12, sz)
@@ -247,7 +253,9 @@ function block_covec_vec_mul!(threading::Threading, C::VecTypes, A, B::VecTypes,
     _mul_add!(threading, C, A12, B21, sz)
 end
 
-@inline function block_mat_mat_mul_add!(::Multithreaded, C, A, B, sz, ::Val{factor} = Val(1)) where {factor}
+@inline function block_mat_mat_mul_add!(multithreaded::Multithreaded, C, A, B, sz, ::Val{factor} = Val(1)) where {factor}
+    use_singlethread(multithreaded, C, A, B) &&
+        return block_mat_mat_mul_add!(singlethreaded, C, A, B, sz, Val(factor))
     mᵣ, nᵣ = LoopVectorization.matmul_params()
     mstep = mᵣ * LoopVectorization.pick_vector_width(eltype(A))
     m1 = min(max(sz, mstep * div(size(A, 1), 2mstep, RoundNearest)), size(A, 1) - sz)
@@ -265,7 +273,7 @@ end
     end
     @sync begin
         Threads.@spawn begin
-            add_gemm_kernel!(C11, A11, B11, Val(factor))
+            _mul_add!(multithreaded, C11, A11, B11, sz, Val(factor))
             _mul_add!(multithreaded, C11, A12, B21, sz, Val(factor))
         end
         Threads.@spawn begin
@@ -302,7 +310,9 @@ end
     _mul_add!(singlethreaded, C22, A22, B22, sz, Val(factor))
 end
 
-function block_mat_vec_mul_add!(::Multithreaded, C, A, B, sz, ::Val{factor} = Val(1)) where {factor}
+function block_mat_vec_mul_add!(multithreaded::Multithreaded, C, A, B, sz, ::Val{factor} = Val(1)) where {factor}
+    use_singlethread(multithreaded, C, A, B) &&
+        return block_mat_vec_mul_add!(singlethreaded, C, A, B, sz, Val(factor))
     mstep = LoopVectorization.pick_vector_width(eltype(A))
     m1 = min(max(sz, mstep * div(size(A, 1), 2mstep, RoundNearest)), size(A, 1) - sz)
     k1 = min(max(sz, div(size(A, 2), 2, RoundNearest)), size(A, 2) - sz)
@@ -318,7 +328,7 @@ function block_mat_vec_mul_add!(::Multithreaded, C, A, B, sz, ::Val{factor} = Va
     end
     @sync begin
         Threads.@spawn begin
-            add_gemm_kernel!(C11, A11, B11, Val(factor))
+            _mul_add!(multithreaded, C11, A11, B11, sz, Val(factor))
             _mul_add!(multithreaded, C11, A12, B21, sz, Val(factor))
         end
         _mul_add!(multithreaded, C21, A21, B11, sz, Val(factor))
@@ -343,7 +353,9 @@ function block_mat_vec_mul_add!(::Singlethreaded, C, A, B, sz, ::Val{factor} = V
     _mul_add!(singlethreaded, C21, A22, B21, sz, Val(factor))
 end
 
-function block_mat_vec_mul_add!(::Multithreaded, C::VecTypes, A, B::VecTypes, sz, ::Val{factor} = Val(1)) where {factor}
+function block_mat_vec_mul_add!(multithreaded::Multithreaded, C::VecTypes, A, B::VecTypes, sz, ::Val{factor} = Val(1)) where {factor}
+    use_singlethread(multithreaded, C, A, B) &&
+        return block_mat_vec_mul_add!(singlethreaded, C, A, B, sz, Val(factor))
     mstep = LoopVectorization.pick_vector_width(eltype(A))
     m1 = min(max(sz, mstep * div(size(A, 1), 2mstep, RoundNearest)), size(A, 1) - sz)
     k1 = min(max(sz, div(size(A, 2), 2, RoundNearest)), size(A, 2) - sz)
@@ -359,7 +371,7 @@ function block_mat_vec_mul_add!(::Multithreaded, C::VecTypes, A, B::VecTypes, sz
     end
     @sync begin
         Threads.@spawn begin
-            add_gemm_kernel!(C11, A11, B11, Val(factor))
+            _mul_add!(multithreaded, C11, A11, B11, sz, Val(factor))
             _mul_add!(multithreaded, C11, A12, B21, sz, Val(factor))
         end
         _mul_add!(multithreaded, C21, A21, B11, sz, Val(factor))
@@ -384,7 +396,9 @@ function block_mat_vec_mul_add!(::Singlethreaded, C::VecTypes, A, B::VecTypes, s
     _mul_add!(singlethreaded, C21, A22, B21, sz, Val(factor))
 end
 
-function block_covec_mat_mul_add!(::Multithreaded, C, A, B, sz, ::Val{factor} = Val(1)) where {factor}
+function block_covec_mat_mul_add!(multithreaded::Multithreaded, C, A, B, sz, ::Val{factor} = Val(1)) where {factor}
+    use_singlethread(multithreaded, C, A, B) &&
+        return block_covec_mat_mul_add!(singlethreaded, C, A, B, sz, Val(factor))
     nstep = LoopVectorization.pick_vector_width(eltype(B))
     n1 = min(max(sz, nstep * div(size(B, 2), 2nstep, RoundNearest)), size(B, 2) - sz)
     k1 = min(max(sz, div(size(A, 2), 2, RoundNearest)), size(A, 2) - sz)
@@ -398,7 +412,7 @@ function block_covec_mat_mul_add!(::Multithreaded, C, A, B, sz, ::Val{factor} = 
     end
     @sync begin
         Threads.@spawn begin
-            add_gemm_kernel!(C11, A11, B11, Val(factor))
+            _mul_add!(multithreaded, C11, A11, B11, sz, Val(factor))
             _mul_add!(multithreaded, C11, A12, B21, sz, Val(factor))
         end
         _mul_add!(multithreaded, C12, A11, B12, sz, Val(factor))
@@ -421,7 +435,9 @@ function block_covec_mat_mul_add!(::Singlethreaded, C, A, B, sz, ::Val{factor} =
     _mul_add!(singlethreaded, C12, A12, B22, sz, Val(factor))
 end
 
-function block_vec_covec_mul_add!(::Multithreaded, C, A, B, sz, ::Val{factor} = Val(1)) where {factor}
+function block_vec_covec_mul_add!(multithreaded::Multithreaded, C, A, B, sz, ::Val{factor} = Val(1)) where {factor}
+    use_singlethread(multithreaded, C, A, B) &&
+        return block_vec_covec_mul_add!(singlethreaded, C, A, B, sz, Val(factor))
     mᵣ, nᵣ = LoopVectorization.matmul_params()
     mstep = mᵣ * LoopVectorization.pick_vector_width(eltype(A))
     m1 = min(max(sz, mstep * div(size(A, 1), 2mstep, RoundNearest)), size(A, 1) - sz)
@@ -437,7 +453,7 @@ function block_vec_covec_mul_add!(::Multithreaded, C, A, B, sz, ::Val{factor} = 
     end
     @sync begin
         Threads.@spawn begin
-            add_gemm_kernel!(C11, A11, B11, Val(factor))
+            _mul_add!(multithreaded, C11, A11, B11, sz, Val(factor))
         end
         Threads.@spawn begin
             _mul_add!(multithreaded, C12, A11, B12, sz, Val(factor))

--- a/src/block_operations.jl
+++ b/src/block_operations.jl
@@ -173,9 +173,9 @@ function block_covec_mat_mul!(::Singlethreaded, C, A, B, sz)
     end
     #_mul!(threading,     C11, A11, B11, sz)
     gemm_kernel!(C11, A11, B11)
-    _mul_add!(multithreaded, C11, A12, B21, sz)
-    _mul!(multithreaded,     C12, A11, B12, sz)
-    _mul_add!(multithreaded, C12, A12, B22, sz)
+    _mul_add!(singlethreaded, C11, A12, B21, sz)
+    _mul!(singlethreaded,     C12, A11, B12, sz)
+    _mul_add!(singlethreaded, C12, A12, B22, sz)
 end
 
 function block_vec_covec_mul!(::Multithreaded, C, A, B, sz)
@@ -379,9 +379,9 @@ function block_mat_vec_mul_add!(::Singlethreaded, C::VecTypes, A, B::VecTypes, s
         B21 = B[sz+1:end];
     end
     add_gemm_kernel!(C11, A11, B11, Val(factor))
-    _mul_add!(multithreaded, C11, A12, B21, sz, Val(factor))
-    _mul_add!(multithreaded, C21, A21, B11, sz, Val(factor))
-    _mul_add!(multithreaded, C21, A22, B21, sz, Val(factor))
+    _mul_add!(singlethreaded, C11, A12, B21, sz, Val(factor))
+    _mul_add!(singlethreaded, C21, A21, B11, sz, Val(factor))
+    _mul_add!(singlethreaded, C21, A22, B21, sz, Val(factor))
 end
 
 function block_covec_mat_mul_add!(::Multithreaded, C, A, B, sz, ::Val{factor} = Val(1)) where {factor}

--- a/src/choose_block_size.jl
+++ b/src/choose_block_size.jl
@@ -7,3 +7,21 @@ function choose_block_size(C, A, B, ::Nothing)
 end
 
 choose_block_size(C, A, B, block_size::Integer) = block_size
+
+function choose_parameter(C, A, B, ::Nothing)
+    m = Int128(size(A, 1))
+    n = Int128(size(B, 1))
+    k = Int128(size(A, 2))
+    oversubscription_ratio = 8  # a magic constant that Works For Me
+    singlethread_size = cld(m * n * k, oversubscription_ratio * Threads.nthreads())
+    return Multithreaded(singlethread_size)
+end
+
+choose_parameter(C, A, B, singlethread_size::Integer) = Multithreaded(singlethread_size)
+
+function use_singlethread(multithreaded::Multithreaded, C, A, B)
+    m = Int128(size(A, 1))
+    n = Int128(size(B, 1))
+    k = Int128(size(A, 2))
+    return m * n * k <= multithreaded.singlethread_size
+end

--- a/src/public_mul.jl
+++ b/src/public_mul.jl
@@ -75,10 +75,12 @@ function mul_serial(A::StructArray{Complex{T}, 2}, B::StructArray{Complex{T}, 2}
 end
 
 function mul!(C::AbstractArray{T}, A::AbstractArray{T}, B::AbstractArray{T};
-              block_size = nothing, sizecheck=true) where {T <: Eltypes}
+              block_size = nothing, singlethread_size = nothing,
+              sizecheck = true) where {T <: Eltypes}
     sizecheck && check_compatible_sizes(C, A, B)
 
     _block_size = choose_block_size(C, A, B, block_size)
+    multithreaded = choose_parameter(C, A, B, singlethread_size)
 
     _mul!(multithreaded, C, A, B, _block_size)
     C
@@ -95,10 +97,12 @@ function mul_serial!(C::AbstractArray{T}, A::AbstractArray{T}, B::AbstractArray{
 end
 
 function mul!(C::StructArray{Complex{T}}, A::StructArray{Complex{T}}, B::StructArray{Complex{T}};
-              block_size = default_block_size(), sizecheck=true) where {T <: Eltypes}
+              block_size = default_block_size(), singlethread_size = nothing,
+              sizecheck = true) where {T <: Eltypes}
     sizecheck && check_compatible_sizes(C.re, A.re, B.re)
 
     _block_size = choose_block_size(C, A, B, block_size)
+    multithreaded = choose_parameter(C, A, B, singlethread_size)
 
     GC.@preserve C A B begin
         Cre, Cim = C.re, C.im
@@ -133,10 +137,12 @@ end
 function mul!(C::Adjoint{Complex{T}, <:StructArray{Complex{T}}},
               A::Adjoint{Complex{T}, <:StructArray{Complex{T}}},
               B::StructArray{Complex{T}};
-              block_size = default_block_size(), sizecheck=true) where {T <: Eltypes}
+              block_size = default_block_size(), singlethread_size = nothing,
+              sizecheck = true) where {T <: Eltypes}
     sizecheck && check_compatible_sizes(C.parent.re', A.parent.re', B.re)
 
     _block_size = choose_block_size(C, A, B, block_size)
+    multithreaded = choose_parameter(C, A, B, singlethread_size)
     A.parent.im .= (-).(A.parent.im) #ugly hack
     GC.@preserve C A B begin
         Cre, Cim = (C.parent.re'), (C.parent.im')
@@ -177,10 +183,12 @@ end
 function mul!(C::Transpose{Complex{T}, <:StructArray{Complex{T}}},
               A::Transpose{Complex{T}, <:StructArray{Complex{T}}},
               B::StructArray{Complex{T}};
-              block_size = default_block_size(), sizecheck=true) where {T <: Eltypes}
+              block_size = default_block_size(), singlethread_size = nothing,
+              sizecheck = true) where {T <: Eltypes}
     sizecheck && check_compatible_sizes(C.parent.re |> transpose, A.parent.re |> transpose, B.re)
 
     _block_size = choose_block_size(C, A, B, block_size)
+    multithreaded = choose_parameter(C, A, B, singlethread_size)
 
     GC.@preserve C A B begin
         Cre, Cim = (C.parent.re |> transpose), (C.parent.im |> transpose)

--- a/src/types.jl
+++ b/src/types.jl
@@ -12,10 +12,11 @@ const CoVecTypes{T} = Union{Adjoint{T,   <:VecTypes{T}},
 abstract type Threading end
 
 struct Multithreaded <: Threading
+    singlethread_size::Int
+    # TODO: Add `block_size`
 end
 
 struct Singlethreaded <: Threading
 end
 
-const multithreaded = Multithreaded()
 const singlethreaded = Singlethreaded()

--- a/src/types.jl
+++ b/src/types.jl
@@ -12,7 +12,7 @@ const CoVecTypes{T} = Union{Adjoint{T,   <:VecTypes{T}},
 abstract type Threading end
 
 struct Multithreaded <: Threading
-    singlethread_size::Int
+    singlethread_size::Int64
     # TODO: Add `block_size`
 end
 

--- a/test/_matmul.jl
+++ b/test/_matmul.jl
@@ -6,7 +6,8 @@
 # `m_values`
 
 @time @testset "_mul!: C, A, B $(testset_name_suffix)" begin
-    for threading in [Gaius.singlethreaded, Gaius.multithreaded]
+    multithreaded = Gaius.Multithreaded(2^24)
+    for threading in [Gaius.singlethreaded, multithreaded]
         for sz in sz_values
             for n in n_values
                 for k in k_values
@@ -27,7 +28,8 @@
 end
 
 @time @testset "_mul!: C::VecTypes, A::MatTypes, B::VecTypes $(testset_name_suffix)" begin
-    for threading in [Gaius.singlethreaded, Gaius.multithreaded]
+    multithreaded = Gaius.Multithreaded(2^24)
+    for threading in [Gaius.singlethreaded, multithreaded]
         for sz in sz_values
             for n in n_values
                 for k in k_values
@@ -48,7 +50,8 @@ end
 end
 
 @time @testset "_mul!: C::CoVecTypes, A::CoVecTypes, B::MatTypes $(testset_name_suffix)" begin
-    for threading in [Gaius.singlethreaded, Gaius.multithreaded]
+    multithreaded = Gaius.Multithreaded(2^24)
+    for threading in [Gaius.singlethreaded, multithreaded]
         for sz in sz_values
             for n in n_values
                 for k in k_values

--- a/test/block_operations.jl
+++ b/test/block_operations.jl
@@ -1,9 +1,10 @@
 @time @testset "block_operations" begin
+    multithreaded = Gaius.Multithreaded(0)
     @testset begin
         A = [1 2; 3 4]
         B = [5 6; 7 8]
         C = Matrix{Int}(undef, 2, 2)
-        Gaius.block_covec_vec_mul!(Gaius.multithreaded, C, A, B, 1)
+        Gaius.block_covec_vec_mul!(multithreaded, C, A, B, 1)
         @test C == A * B
     end
 
@@ -11,7 +12,7 @@
         A = [1 2; 3 4]
         B = [5, 6]
         C = Vector{Int}(undef, 2)
-        Gaius.block_covec_vec_mul!(Gaius.multithreaded, C, A, B, 1)
+        Gaius.block_covec_vec_mul!(multithreaded, C, A, B, 1)
         @test C == A * B
     end
 end


### PR DESCRIPTION
This PR is a continuation of #83 and tries to generate more balanced DAG for all GEMM implementations.  As the benchmarks below shows, this PR shows speedup over the current `master` for most of the parameters I tried and there's virtually no slowdown.

The main change is to always use `_mul!(multithreaded, ...)` etc. like this

```diff
diff --git a/src/block_operations.jl b/src/block_operations.jl
index 4ddab77..bb8d753 100644
--- a/src/block_operations.jl
+++ b/src/block_operations.jl
@@ -16,8 +18,7 @@
     end
     @sync begin
         Threads.@spawn begin
-            #_mul!(multithreaded,     C11, A11, B11, sz)
-            gemm_kernel!(C11, A11, B11)
+            _mul!(multithreaded,     C11, A11, B11, sz)
             _mul_add!(multithreaded, C11, A12, B21, sz)
         end
         Threads.@spawn begin
```

so that the task DAG is more symmetric and expresses richer parallelism.

To avoid this to generate too many `Task`s for `julia` to handle, I suggest to "bail out" multi-threaded recursion once the estimated time-complexity `M * N * K` is small enough (= "two-phase recursion")

https://github.com/MasonProtter/Gaius.jl/blob/d6ea836ad092dc4bd5942cc276965b9ee505e090/src/block_operations.jl#L1-L3

To propagate the threshold parameter across the recursions, I added `singlethread_size` field to `struct Multithreaded`

https://github.com/MasonProtter/Gaius.jl/blob/d6ea836ad092dc4bd5942cc276965b9ee505e090/src/types.jl#L14-L17

since we already pass it around. As the TODO comment says, it may be worth getting rid of the explicit argument `sz` (`block_size`) to all `_mul!`-variants by including the `block_size` field (maybe in a follow-up refactoring PR). I think this is a nice way to pass around multiple parameters across recursion.

close #85

## Benchmarks

Benchmark driver scripts:
https://gist.github.com/tkf/19d0e682253bb4f944b1c143641451fb

Plots:
https://gist.github.com/tkf/2b95055b67db0bbccecbc99d078c4514

The y axis of the following plots show the speedup; i.e., the ratio `T_baseline / T_target` of the benchmarked minimum times where the baseline is the current `master` branch b39d597f8ff3435e92fcb6d9bb3ff7fd2ae850c5 and the target is this PR d6ea836ad092dc4bd5942cc276965b9ee505e090.

### Matrix-matrix multiplication

![image](https://user-images.githubusercontent.com/29282/140583719-7cba47a0-c2ed-4955-8ff2-3b6117d111d8.png)

### Matrix-vector multiplication

![image](https://user-images.githubusercontent.com/29282/140583746-df93c54a-7fa8-420f-9b45-cd87195e6735.png)
