### PR TITLE
Refactoring: Move `block_size` to `Threading` type

### DIFF
--- a/src/block_operations.jl
+++ b/src/block_operations.jl
@@ -1,6 +1,7 @@
-@inline function block_mat_mat_mul!(multithreaded::Multithreaded, C, A, B, sz)
+@inline function block_mat_mat_mul!(multithreaded::Multithreaded, C, A, B)
     use_singlethread(multithreaded, C, A, B) &&
-        return block_mat_mat_mul!(singlethreaded, C, A, B, sz)
+        return block_mat_mat_mul!(multithreaded.singlethreaded, C, A, B)
+    sz = get_block_size(multithreaded)
     mᵣ, nᵣ = LoopVectorization.matmul_params()
     mstep = mᵣ * LoopVectorization.pick_vector_width(eltype(A))
     m1 = min(max(sz, mstep * div(size(A, 1), 2mstep, RoundNearest)), size(A, 1) - sz)
@@ -18,23 +19,24 @@
     end
     @sync begin
         Threads.@spawn begin
-            _mul!(multithreaded,     C11, A11, B11, sz)
-            _mul_add!(multithreaded, C11, A12, B21, sz)
+            _mul!(multithreaded,     C11, A11, B11)
+            _mul_add!(multithreaded, C11, A12, B21)
         end
         Threads.@spawn begin
-            _mul!(multithreaded,     C12, A11, B12, sz)
-            _mul_add!(multithreaded, C12, A12, B22, sz)
+            _mul!(multithreaded,     C12, A11, B12)
+            _mul_add!(multithreaded, C12, A12, B22)
         end
         Threads.@spawn begin
-            _mul!(multithreaded,     C21, A21, B11, sz)
-            _mul_add!(multithreaded, C21, A22, B21, sz)
+            _mul!(multithreaded,     C21, A21, B11)
+            _mul_add!(multithreaded, C21, A22, B21)
         end
-        _mul!(multithreaded,     C22, A21, B12, sz)
-        _mul_add!(multithreaded, C22, A22, B22, sz)
+        _mul!(multithreaded,     C22, A21, B12)
+        _mul_add!(multithreaded, C22, A22, B22)
     end
 end
 
-@inline function block_mat_mat_mul!(::Singlethreaded, C, A, B, sz)
+@inline function block_mat_mat_mul!(singlethreaded::Singlethreaded, C, A, B)
+    sz = get_block_size(singlethreaded)
     @inbounds @views begin
         C11 = C[1:sz,     1:sz]; C12 = C[1:sz,     sz+1:end]
         C21 = C[sz+1:end, 1:sz]; C22 = C[sz+1:end, sz+1:end]
@@ -45,20 +47,21 @@ end
         B11 = B[1:sz,     1:sz]; B12 = B[1:sz,     sz+1:end]
         B21 = B[sz+1:end, 1:sz]; B22 = B[sz+1:end, sz+1:end]
     end
-    #_mul!(singlethreaded,     C11, A11, B11, sz)
+    #_mul!(singlethreaded,     C11, A11, B11)
     gemm_kernel!(C11, A11, B11)
-    _mul_add!(singlethreaded, C11, A12, B21, sz)
-    _mul!(singlethreaded,     C12, A11, B12, sz)
-    _mul_add!(singlethreaded, C12, A12, B22, sz)
-    _mul!(singlethreaded,     C21, A21, B11, sz)
-    _mul_add!(singlethreaded, C21, A22, B21, sz)
-    _mul!(singlethreaded,     C22, A21, B12, sz)
-    _mul_add!(singlethreaded, C22, A22, B22, sz)
+    _mul_add!(singlethreaded, C11, A12, B21)
+    _mul!(singlethreaded,     C12, A11, B12)
+    _mul_add!(singlethreaded, C12, A12, B22)
+    _mul!(singlethreaded,     C21, A21, B11)
+    _mul_add!(singlethreaded, C21, A22, B21)
+    _mul!(singlethreaded,     C22, A21, B12)
+    _mul_add!(singlethreaded, C22, A22, B22)
 end
 
-function block_mat_vec_mul!(multithreaded::Multithreaded, C, A, B, sz)
+function block_mat_vec_mul!(multithreaded::Multithreaded, C, A, B)
     use_singlethread(multithreaded, C, A, B) &&
-        return block_mat_vec_mul!(singlethreaded, C, A, B, sz)
+        return block_mat_vec_mul!(multithreaded.singlethreaded, C, A, B)
+    sz = get_block_size(multithreaded)
     mstep = LoopVectorization.pick_vector_width(eltype(A))
     m1 = min(max(sz, mstep * div(size(A, 1), 2mstep, RoundNearest)), size(A, 1) - sz)
     k1 = min(max(sz, div(size(A, 2), 2, RoundNearest)), size(A, 2) - sz)
@@ -74,15 +77,16 @@ function block_mat_vec_mul!(multithreaded::Multithreaded, C, A, B, sz)
     end
     @sync begin
         Threads.@spawn begin
-            _mul!(multithreaded,     C11, A11, B11, sz)
-            _mul_add!(multithreaded, C11, A12, B21, sz)
+            _mul!(multithreaded,     C11, A11, B11)
+            _mul_add!(multithreaded, C11, A12, B21)
         end
-        _mul!(multithreaded,     C21, A21, B11, sz)
-        _mul_add!(multithreaded, C21, A22, B21, sz)
+        _mul!(multithreaded,     C21, A21, B11)
+        _mul_add!(multithreaded, C21, A22, B21)
     end
 end
 
-function block_mat_vec_mul!(::Singlethreaded, C, A, B, sz)
+function block_mat_vec_mul!(singlethreaded::Singlethreaded, C, A, B)
+    sz = get_block_size(singlethreaded)
     @inbounds @views begin
         C11 = C[1:sz,     1:end];
         C21 = C[sz+1:end, 1:end];
@@ -93,16 +97,17 @@ function block_mat_vec_mul!(::Singlethreaded, C, A, B, sz)
         B11 = B[1:sz,     1:end];
         B21 = B[sz+1:end, 1:end];
     end
-    #_mul!(singlethreaded,     C11, A11, B11, sz)
+    #_mul!(singlethreaded,     C11, A11, B11)
     gemm_kernel!(C11, A11, B11)
-    _mul_add!(singlethreaded, C11, A12, B21, sz)
-    _mul!(singlethreaded,     C21, A21, B11, sz)
-    _mul_add!(singlethreaded, C21, A22, B21, sz)
+    _mul_add!(singlethreaded, C11, A12, B21)
+    _mul!(singlethreaded,     C21, A21, B11)
+    _mul_add!(singlethreaded, C21, A22, B21)
 end
 
-function block_mat_vec_mul!(multithreaded::Multithreaded, C::VecTypes, A, B::VecTypes, sz)
+function block_mat_vec_mul!(multithreaded::Multithreaded, C::VecTypes, A, B::VecTypes)
     use_singlethread(multithreaded, C, A, B) &&
-        return block_mat_vec_mul!(singlethreaded, C, A, B, sz)
+        return block_mat_vec_mul!(multithreaded.singlethreaded, C, A, B)
+    sz = get_block_size(multithreaded)
     mstep = LoopVectorization.pick_vector_width(eltype(A))
     m1 = min(max(sz, mstep * div(size(A, 1), 2mstep, RoundNearest)), size(A, 1) - sz)
     k1 = min(max(sz, div(size(A, 2), 2, RoundNearest)), size(A, 2) - sz)
@@ -118,15 +123,16 @@ function block_mat_vec_mul!(multithreaded::Multithreaded, C::VecTypes, A, B::Vec
     end
     @sync begin
         Threads.@spawn begin
-            _mul!(multithreaded,     C11, A11, B11, sz)
-            _mul_add!(multithreaded, C11, A12, B21, sz)
+            _mul!(multithreaded,     C11, A11, B11)
+            _mul_add!(multithreaded, C11, A12, B21)
         end
-        _mul!(multithreaded,     C21, A21, B11, sz)
-        _mul_add!(multithreaded, C21, A22, B21, sz)
+        _mul!(multithreaded,     C21, A21, B11)
+        _mul_add!(multithreaded, C21, A22, B21)
     end
 end
 
-function block_mat_vec_mul!(::Singlethreaded, C::VecTypes, A, B::VecTypes, sz)
+function block_mat_vec_mul!(singlethreaded::Singlethreaded, C::VecTypes, A, B::VecTypes)
+    sz = get_block_size(singlethreaded)
     @inbounds @views begin
         C11 = C[1:sz    ];
         C21 = C[sz+1:end];
@@ -138,14 +144,15 @@ function block_mat_vec_mul!(::Singlethreaded, C::VecTypes, A, B::VecTypes, sz)
         B21 = B[sz+1:end];
     end
     gemm_kernel!(C11, A11, B11)
-    _mul_add!(singlethreaded, C11, A12, B21, sz)
-    _mul!(singlethreaded,     C21, A21, B11, sz)
-    _mul_add!(singlethreaded, C21, A22, B21, sz)
+    _mul_add!(singlethreaded, C11, A12, B21)
+    _mul!(singlethreaded,     C21, A21, B11)
+    _mul_add!(singlethreaded, C21, A22, B21)
 end
 
-function block_covec_mat_mul!(multithreaded::Multithreaded, C, A, B, sz)
+function block_covec_mat_mul!(multithreaded::Multithreaded, C, A, B)
     use_singlethread(multithreaded, C, A, B) &&
-        return block_covec_mat_mul!(singlethreaded, C, A, B, sz)
+        return block_covec_mat_mul!(multithreaded.singlethreaded, C, A, B)
+    sz = get_block_size(multithreaded)
     nstep = LoopVectorization.pick_vector_width(eltype(B))
     n1 = min(max(sz, nstep * div(size(B, 2), 2nstep, RoundNearest)), size(B, 2) - sz)
     k1 = min(max(sz, div(size(A, 2), 2, RoundNearest)), size(A, 2) - sz)
@@ -159,15 +166,16 @@ function block_covec_mat_mul!(multithreaded::Multithreaded, C, A, B, sz)
     end
     @sync begin
         Threads.@spawn begin
-            _mul!(multithreaded,     C11, A11, B11, sz)
-            _mul_add!(multithreaded, C11, A12, B21, sz)
+            _mul!(multithreaded,     C11, A11, B11)
+            _mul_add!(multithreaded, C11, A12, B21)
         end
-        _mul!(multithreaded,     C12, A11, B12, sz)
-        _mul_add!(multithreaded, C12, A12, B22, sz)
+        _mul!(multithreaded,     C12, A11, B12)
+        _mul_add!(multithreaded, C12, A12, B22)
     end
 end
 
-function block_covec_mat_mul!(::Singlethreaded, C, A, B, sz)
+function block_covec_mat_mul!(singlethreaded::Singlethreaded, C, A, B)
+    sz = get_block_size(singlethreaded)
     @inbounds @views begin
         C11 = C[1:end,    1:sz]; C12 = C[1:end,    sz+1:end]
 
@@ -176,16 +184,17 @@ function block_covec_mat_mul!(::Singlethreaded, C, A, B, sz)
         B11 = B[1:sz,     1:sz]; B12 = B[1:sz,     sz+1:end]
         B21 = B[sz+1:end, 1:sz]; B22 = B[sz+1:end, sz+1:end]
     end
-    #_mul!(threading,     C11, A11, B11, sz)
+    #_mul!(threading,     C11, A11, B11)
     gemm_kernel!(C11, A11, B11)
-    _mul_add!(singlethreaded, C11, A12, B21, sz)
-    _mul!(singlethreaded,     C12, A11, B12, sz)
-    _mul_add!(singlethreaded, C12, A12, B22, sz)
+    _mul_add!(singlethreaded, C11, A12, B21)
+    _mul!(singlethreaded,     C12, A11, B12)
+    _mul_add!(singlethreaded, C12, A12, B22)
 end
 
-function block_vec_covec_mul!(multithreaded::Multithreaded, C, A, B, sz)
+function block_vec_covec_mul!(multithreaded::Multithreaded, C, A, B)
     use_singlethread(multithreaded, C, A, B) &&
-        return block_vec_covec_mul!(singlethreaded, C, A, B, sz)
+        return block_vec_covec_mul!(multithreaded.singlethreaded, C, A, B)
+    sz = get_block_size(multithreaded)
     mᵣ, nᵣ = LoopVectorization.matmul_params()
     mstep = mᵣ * LoopVectorization.pick_vector_width(eltype(A))
     m1 = min(max(sz, mstep * div(size(A, 1), 2mstep, RoundNearest)), size(A, 1) - sz)
@@ -201,19 +210,20 @@ function block_vec_covec_mul!(multithreaded::Multithreaded, C, A, B, sz)
     end
     @sync begin
         Threads.@spawn begin
-            _mul!(multithreaded, C11, A11, B11, sz)
+            _mul!(multithreaded, C11, A11, B11)
         end
         Threads.@spawn begin
-            _mul!(multithreaded, C12, A11, B12, sz)
+            _mul!(multithreaded, C12, A11, B12)
         end
         Threads.@spawn begin
-            _mul!(multithreaded, C21, A21, B11, sz)
+            _mul!(multithreaded, C21, A21, B11)
         end
-        _mul!(multithreaded, C22, A21, B12, sz)
+        _mul!(multithreaded, C22, A21, B12)
     end
 end
 
-function block_vec_covec_mul!(::Singlethreaded, C, A, B, sz)
+function block_vec_covec_mul!(singlethreaded::Singlethreaded, C, A, B)
+    sz = get_block_size(singlethreaded)
     @inbounds @views begin
         C11 = C[1:sz,     1:sz]; C12 = C[1:sz,     sz+1:end]
         C21 = C[sz+1:end, 1:sz]; C22 = C[sz+1:end, sz+1:end]
@@ -223,14 +233,15 @@ function block_vec_covec_mul!(::Singlethreaded, C, A, B, sz)
 
         B11 = B[1:end,     1:sz]; B12 = B[1:end,     sz+1:end]
     end
-    #_mul!(singlethreaded,     C11, A11, B11, sz)
+    #_mul!(singlethreaded,     C11, A11, B11)
     gemm_kernel!(C11, A11, B11)
-    _mul!(singlethreaded, C12, A11, B12, sz)
-    _mul!(singlethreaded, C21, A21, B11, sz)
-    _mul!(singlethreaded, C22, A21, B12, sz)
+    _mul!(singlethreaded, C12, A11, B12)
+    _mul!(singlethreaded, C21, A21, B11)
+    _mul!(singlethreaded, C22, A21, B12)
 end
 
-function block_covec_vec_mul!(threading::Threading, C, A, B, sz)
+function block_covec_vec_mul!(threading::Threading, C, A, B)
+    sz = get_block_size(threading)
     @inbounds @views begin
         A11 = A[1:end,    1:sz]; A12 = A[1:end,     sz+1:end]
 
@@ -238,11 +249,12 @@ function block_covec_vec_mul!(threading::Threading, C, A, B, sz)
         B21 = B[sz+1:end, 1:end];
     end
     gemm_kernel!(C, A11, B11)
-    #_mul!(threading,     C, A11, B11, sz)
-    _mul_add!(threading, C, A12, B21, sz)
+    #_mul!(threading,     C, A11, B11)
+    _mul_add!(threading, C, A12, B21)
 end
 
-function block_covec_vec_mul!(threading::Threading, C::VecTypes, A, B::VecTypes, sz)
+function block_covec_vec_mul!(threading::Threading, C::VecTypes, A, B::VecTypes)
+    sz = get_block_size(threading)
     @inbounds @views begin
         A11 = A[1:end,    1:sz]; A12 = A[1:end,     sz+1:end]
 
@@ -250,12 +262,13 @@ function block_covec_vec_mul!(threading::Threading, C::VecTypes, A, B::VecTypes,
         B21 = B[sz+1:end];
     end
     gemm_kernel!(C, A11, B11)
-    _mul_add!(threading, C, A12, B21, sz)
+    _mul_add!(threading, C, A12, B21)
 end
 
-@inline function block_mat_mat_mul_add!(multithreaded::Multithreaded, C, A, B, sz, ::Val{factor} = Val(1)) where {factor}
+@inline function block_mat_mat_mul_add!(multithreaded::Multithreaded, C, A, B, ::Val{factor} = Val(1)) where {factor}
     use_singlethread(multithreaded, C, A, B) &&
-        return block_mat_mat_mul_add!(singlethreaded, C, A, B, sz, Val(factor))
+        return block_mat_mat_mul_add!(multithreaded.singlethreaded, C, A, B, Val(factor))
+    sz = get_block_size(multithreaded)
     mᵣ, nᵣ = LoopVectorization.matmul_params()
     mstep = mᵣ * LoopVectorization.pick_vector_width(eltype(A))
     m1 = min(max(sz, mstep * div(size(A, 1), 2mstep, RoundNearest)), size(A, 1) - sz)
@@ -273,23 +286,24 @@ end
     end
     @sync begin
         Threads.@spawn begin
-            _mul_add!(multithreaded, C11, A11, B11, sz, Val(factor))
-            _mul_add!(multithreaded, C11, A12, B21, sz, Val(factor))
+            _mul_add!(multithreaded, C11, A11, B11, Val(factor))
+            _mul_add!(multithreaded, C11, A12, B21, Val(factor))
         end
         Threads.@spawn begin
-            _mul_add!(multithreaded, C12, A11, B12, sz, Val(factor))
-            _mul_add!(multithreaded, C12, A12, B22, sz, Val(factor))
+            _mul_add!(multithreaded, C12, A11, B12, Val(factor))
+            _mul_add!(multithreaded, C12, A12, B22, Val(factor))
         end
         Threads.@spawn begin
-            _mul_add!(multithreaded, C21, A21, B11, sz, Val(factor))
-            _mul_add!(multithreaded, C21, A22, B21, sz, Val(factor))
+            _mul_add!(multithreaded, C21, A21, B11, Val(factor))
+            _mul_add!(multithreaded, C21, A22, B21, Val(factor))
         end
-        _mul_add!(multithreaded, C22, A21, B12, sz, Val(factor))
-        _mul_add!(multithreaded, C22, A22, B22, sz, Val(factor))
+        _mul_add!(multithreaded, C22, A21, B12, Val(factor))
+        _mul_add!(multithreaded, C22, A22, B22, Val(factor))
     end
 end
 
-@inline function block_mat_mat_mul_add!(::Singlethreaded, C, A, B, sz, ::Val{factor} = Val(1)) where {factor}
+@inline function block_mat_mat_mul_add!(singlethreaded::Singlethreaded, C, A, B, ::Val{factor} = Val(1)) where {factor}
+    sz = get_block_size(singlethreaded)
     @inbounds @views begin
         C11 = C[1:sz,     1:sz]; C12 = C[1:sz,     sz+1:end]
         C21 = C[sz+1:end, 1:sz]; C22 = C[sz+1:end, sz+1:end]
@@ -301,18 +315,19 @@ end
         B21 = B[sz+1:end, 1:sz]; B22 = B[sz+1:end, sz+1:end]
     end
     add_gemm_kernel!(C11, A11, B11, Val(factor))
-    _mul_add!(singlethreaded, C11, A12, B21, sz, Val(factor))
-    _mul_add!(singlethreaded, C12, A11, B12, sz, Val(factor))
-    _mul_add!(singlethreaded, C12, A12, B22, sz, Val(factor))
-    _mul_add!(singlethreaded, C21, A21, B11, sz, Val(factor))
-    _mul_add!(singlethreaded, C21, A22, B21, sz, Val(factor))
-    _mul_add!(singlethreaded, C22, A21, B12, sz, Val(factor))
-    _mul_add!(singlethreaded, C22, A22, B22, sz, Val(factor))
+    _mul_add!(singlethreaded, C11, A12, B21, Val(factor))
+    _mul_add!(singlethreaded, C12, A11, B12, Val(factor))
+    _mul_add!(singlethreaded, C12, A12, B22, Val(factor))
+    _mul_add!(singlethreaded, C21, A21, B11, Val(factor))
+    _mul_add!(singlethreaded, C21, A22, B21, Val(factor))
+    _mul_add!(singlethreaded, C22, A21, B12, Val(factor))
+    _mul_add!(singlethreaded, C22, A22, B22, Val(factor))
 end
 
-function block_mat_vec_mul_add!(multithreaded::Multithreaded, C, A, B, sz, ::Val{factor} = Val(1)) where {factor}
+function block_mat_vec_mul_add!(multithreaded::Multithreaded, C, A, B, ::Val{factor} = Val(1)) where {factor}
     use_singlethread(multithreaded, C, A, B) &&
-        return block_mat_vec_mul_add!(singlethreaded, C, A, B, sz, Val(factor))
+        return block_mat_vec_mul_add!(multithreaded.singlethreaded, C, A, B, Val(factor))
+    sz = get_block_size(multithreaded)
     mstep = LoopVectorization.pick_vector_width(eltype(A))
     m1 = min(max(sz, mstep * div(size(A, 1), 2mstep, RoundNearest)), size(A, 1) - sz)
     k1 = min(max(sz, div(size(A, 2), 2, RoundNearest)), size(A, 2) - sz)
@@ -328,15 +343,16 @@ function block_mat_vec_mul_add!(multithreaded::Multithreaded, C, A, B, sz, ::Val
     end
     @sync begin
         Threads.@spawn begin
-            _mul_add!(multithreaded, C11, A11, B11, sz, Val(factor))
-            _mul_add!(multithreaded, C11, A12, B21, sz, Val(factor))
+            _mul_add!(multithreaded, C11, A11, B11, Val(factor))
+            _mul_add!(multithreaded, C11, A12, B21, Val(factor))
         end
-        _mul_add!(multithreaded, C21, A21, B11, sz, Val(factor))
-        _mul_add!(multithreaded, C21, A22, B21, sz, Val(factor))
+        _mul_add!(multithreaded, C21, A21, B11, Val(factor))
+        _mul_add!(multithreaded, C21, A22, B21, Val(factor))
     end
 end
 
-function block_mat_vec_mul_add!(::Singlethreaded, C, A, B, sz, ::Val{factor} = Val(1)) where {factor}
+function block_mat_vec_mul_add!(singlethreaded::Singlethreaded, C, A, B, ::Val{factor} = Val(1)) where {factor}
+    sz = get_block_size(singlethreaded)
     @inbounds @views begin
         C11 = C[1:sz,     1:end];
         C21 = C[sz+1:end, 1:end];
@@ -348,14 +364,15 @@ function block_mat_vec_mul_add!(::Singlethreaded, C, A, B, sz, ::Val{factor} = V
         B21 = B[sz+1:end, 1:end];
     end
     add_gemm_kernel!(C11, A11, B11, Val(factor))
-    _mul_add!(singlethreaded, C11, A12, B21, sz, Val(factor))
-    _mul_add!(singlethreaded, C21, A21, B11, sz, Val(factor))
-    _mul_add!(singlethreaded, C21, A22, B21, sz, Val(factor))
+    _mul_add!(singlethreaded, C11, A12, B21, Val(factor))
+    _mul_add!(singlethreaded, C21, A21, B11, Val(factor))
+    _mul_add!(singlethreaded, C21, A22, B21, Val(factor))
 end
 
-function block_mat_vec_mul_add!(multithreaded::Multithreaded, C::VecTypes, A, B::VecTypes, sz, ::Val{factor} = Val(1)) where {factor}
+function block_mat_vec_mul_add!(multithreaded::Multithreaded, C::VecTypes, A, B::VecTypes, ::Val{factor} = Val(1)) where {factor}
     use_singlethread(multithreaded, C, A, B) &&
-        return block_mat_vec_mul_add!(singlethreaded, C, A, B, sz, Val(factor))
+        return block_mat_vec_mul_add!(multithreaded.singlethreaded, C, A, B, Val(factor))
+    sz = get_block_size(multithreaded)
     mstep = LoopVectorization.pick_vector_width(eltype(A))
     m1 = min(max(sz, mstep * div(size(A, 1), 2mstep, RoundNearest)), size(A, 1) - sz)
     k1 = min(max(sz, div(size(A, 2), 2, RoundNearest)), size(A, 2) - sz)
@@ -371,15 +388,16 @@ function block_mat_vec_mul_add!(multithreaded::Multithreaded, C::VecTypes, A, B:
     end
     @sync begin
         Threads.@spawn begin
-            _mul_add!(multithreaded, C11, A11, B11, sz, Val(factor))
-            _mul_add!(multithreaded, C11, A12, B21, sz, Val(factor))
+            _mul_add!(multithreaded, C11, A11, B11, Val(factor))
+            _mul_add!(multithreaded, C11, A12, B21, Val(factor))
         end
-        _mul_add!(multithreaded, C21, A21, B11, sz, Val(factor))
-        _mul_add!(multithreaded, C21, A22, B21, sz, Val(factor))
+        _mul_add!(multithreaded, C21, A21, B11, Val(factor))
+        _mul_add!(multithreaded, C21, A22, B21, Val(factor))
     end
 end
 
-function block_mat_vec_mul_add!(::Singlethreaded, C::VecTypes, A, B::VecTypes, sz, ::Val{factor} = Val(1)) where {factor}
+function block_mat_vec_mul_add!(singlethreaded::Singlethreaded, C::VecTypes, A, B::VecTypes, ::Val{factor} = Val(1)) where {factor}
+    sz = get_block_size(singlethreaded)
     @inbounds @views begin
         C11 = C[1:sz    ];
         C21 = C[sz+1:end];
@@ -391,14 +409,15 @@ function block_mat_vec_mul_add!(::Singlethreaded, C::VecTypes, A, B::VecTypes, s
         B21 = B[sz+1:end];
     end
     add_gemm_kernel!(C11, A11, B11, Val(factor))
-    _mul_add!(singlethreaded, C11, A12, B21, sz, Val(factor))
-    _mul_add!(singlethreaded, C21, A21, B11, sz, Val(factor))
-    _mul_add!(singlethreaded, C21, A22, B21, sz, Val(factor))
+    _mul_add!(singlethreaded, C11, A12, B21, Val(factor))
+    _mul_add!(singlethreaded, C21, A21, B11, Val(factor))
+    _mul_add!(singlethreaded, C21, A22, B21, Val(factor))
 end
 
-function block_covec_mat_mul_add!(multithreaded::Multithreaded, C, A, B, sz, ::Val{factor} = Val(1)) where {factor}
+function block_covec_mat_mul_add!(multithreaded::Multithreaded, C, A, B, ::Val{factor} = Val(1)) where {factor}
     use_singlethread(multithreaded, C, A, B) &&
-        return block_covec_mat_mul_add!(singlethreaded, C, A, B, sz, Val(factor))
+        return block_covec_mat_mul_add!(multithreaded.singlethreaded, C, A, B, Val(factor))
+    sz = get_block_size(multithreaded)
     nstep = LoopVectorization.pick_vector_width(eltype(B))
     n1 = min(max(sz, nstep * div(size(B, 2), 2nstep, RoundNearest)), size(B, 2) - sz)
     k1 = min(max(sz, div(size(A, 2), 2, RoundNearest)), size(A, 2) - sz)
@@ -412,15 +431,16 @@ function block_covec_mat_mul_add!(multithreaded::Multithreaded, C, A, B, sz, ::V
     end
     @sync begin
         Threads.@spawn begin
-            _mul_add!(multithreaded, C11, A11, B11, sz, Val(factor))
-            _mul_add!(multithreaded, C11, A12, B21, sz, Val(factor))
+            _mul_add!(multithreaded, C11, A11, B11, Val(factor))
+            _mul_add!(multithreaded, C11, A12, B21, Val(factor))
         end
-        _mul_add!(multithreaded, C12, A11, B12, sz, Val(factor))
-        _mul_add!(multithreaded, C12, A12, B22, sz, Val(factor))
+        _mul_add!(multithreaded, C12, A11, B12, Val(factor))
+        _mul_add!(multithreaded, C12, A12, B22, Val(factor))
     end
 end
 
-function block_covec_mat_mul_add!(::Singlethreaded, C, A, B, sz, ::Val{factor} = Val(1)) where {factor}
+function block_covec_mat_mul_add!(singlethreaded::Singlethreaded, C, A, B, ::Val{factor} = Val(1)) where {factor}
+    sz = get_block_size(singlethreaded)
     @inbounds @views begin
         C11 = C[1:end,    1:sz]; C12 = C[1:end,     sz+1:end]
 
@@ -430,14 +450,15 @@ function block_covec_mat_mul_add!(::Singlethreaded, C, A, B, sz, ::Val{factor} =
         B21 = B[sz+1:end, 1:sz]; B22 = B[sz+1:end, sz+1:end]
     end
     add_gemm_kernel!(C11, A11, B11, Val(factor))
-    _mul_add!(singlethreaded, C11, A12, B21, sz, Val(factor))
-    _mul_add!(singlethreaded, C12, A11, B12, sz, Val(factor))
-    _mul_add!(singlethreaded, C12, A12, B22, sz, Val(factor))
+    _mul_add!(singlethreaded, C11, A12, B21, Val(factor))
+    _mul_add!(singlethreaded, C12, A11, B12, Val(factor))
+    _mul_add!(singlethreaded, C12, A12, B22, Val(factor))
 end
 
-function block_vec_covec_mul_add!(multithreaded::Multithreaded, C, A, B, sz, ::Val{factor} = Val(1)) where {factor}
+function block_vec_covec_mul_add!(multithreaded::Multithreaded, C, A, B, ::Val{factor} = Val(1)) where {factor}
     use_singlethread(multithreaded, C, A, B) &&
-        return block_vec_covec_mul_add!(singlethreaded, C, A, B, sz, Val(factor))
+        return block_vec_covec_mul_add!(multithreaded.singlethreaded, C, A, B, Val(factor))
+    sz = get_block_size(multithreaded)
     mᵣ, nᵣ = LoopVectorization.matmul_params()
     mstep = mᵣ * LoopVectorization.pick_vector_width(eltype(A))
     m1 = min(max(sz, mstep * div(size(A, 1), 2mstep, RoundNearest)), size(A, 1) - sz)
@@ -453,19 +474,20 @@ function block_vec_covec_mul_add!(multithreaded::Multithreaded, C, A, B, sz, ::V
     end
     @sync begin
         Threads.@spawn begin
-            _mul_add!(multithreaded, C11, A11, B11, sz, Val(factor))
+            _mul_add!(multithreaded, C11, A11, B11, Val(factor))
         end
         Threads.@spawn begin
-            _mul_add!(multithreaded, C12, A11, B12, sz, Val(factor))
+            _mul_add!(multithreaded, C12, A11, B12, Val(factor))
         end
         Threads.@spawn begin
-            _mul_add!(multithreaded, C21, A21, B11, sz, Val(factor))
+            _mul_add!(multithreaded, C21, A21, B11, Val(factor))
         end
-        _mul_add!(multithreaded, C22, A21, B12, sz, Val(factor))
+        _mul_add!(multithreaded, C22, A21, B12, Val(factor))
     end
 end
 
-function block_vec_covec_mul_add!(::Singlethreaded, C, A, B, sz, ::Val{factor} = Val(1)) where {factor}
+function block_vec_covec_mul_add!(singlethreaded::Singlethreaded, C, A, B, ::Val{factor} = Val(1)) where {factor}
+    sz = get_block_size(singlethreaded)
     @inbounds @views begin
         C11 = C[1:sz,     1:sz]; C12 = C[1:sz,     sz+1:end]
         C21 = C[sz+1:end, 1:sz]; C22 = C[sz+1:end, sz+1:end]
@@ -476,12 +498,13 @@ function block_vec_covec_mul_add!(::Singlethreaded, C, A, B, sz, ::Val{factor} =
         B11 = B[1:end,    1:sz]; B12 = B[1:end,    sz+1:end]
     end
     add_gemm_kernel!(C11, A11, B11, Val(factor))
-    _mul_add!(singlethreaded, C12, A11, B12, sz, Val(factor))
-    _mul_add!(singlethreaded, C21, A21, B11, sz, Val(factor))
-    _mul_add!(singlethreaded, C22, A21, B12, sz, Val(factor))
+    _mul_add!(singlethreaded, C12, A11, B12, Val(factor))
+    _mul_add!(singlethreaded, C21, A21, B11, Val(factor))
+    _mul_add!(singlethreaded, C22, A21, B12, Val(factor))
 end
 
-function block_covec_vec_mul_add!(threading::Threading, C, A, B, sz, ::Val{factor} = Val(1)) where {factor}
+function block_covec_vec_mul_add!(threading::Threading, C, A, B, ::Val{factor} = Val(1)) where {factor}
+    sz = get_block_size(threading)
     @inbounds @views begin
         A11 = A[1:end,    1:sz]; A12 = A[1:end,    sz+1:end]
 
@@ -489,10 +512,11 @@ function block_covec_vec_mul_add!(threading::Threading, C, A, B, sz, ::Val{facto
         B21 = B[sz+1:end, 1:end];
     end
     add_gemm_kernel!(C, A11, B11, Val(factor))
-    _mul_add!(threading, C, A12, B21, sz, Val(factor))
+    _mul_add!(threading, C, A12, B21, Val(factor))
 end
 
-function block_covec_vec_mul_add!(threading::Threading, C::VecTypes, A, B::VecTypes, sz, ::Val{factor} = Val(1)) where {factor}
+function block_covec_vec_mul_add!(threading::Threading, C::VecTypes, A, B::VecTypes, ::Val{factor} = Val(1)) where {factor}
+    sz = get_block_size(threading)
     @inbounds @views begin
         A11 = A[1:end,    1:sz]; A12 = A[1:end,    sz+1:end]
 
@@ -500,5 +524,5 @@ function block_covec_vec_mul_add!(threading::Threading, C::VecTypes, A, B::VecTy
         B21 = B[sz+1:end];
     end
     add_gemm_kernel!(C, A11, B11, Val(factor))
-    _mul_add!(threading, C, A12, B21, sz, Val(factor))
+    _mul_add!(threading, C, A12, B21, Val(factor))
 end

--- a/src/choose_block_size.jl
+++ b/src/choose_block_size.jl
@@ -8,10 +8,10 @@ end
 
 choose_block_size(C, A, B, block_size::Integer) = block_size
 
-choose_parameter(::Type{Singlethreaded}, C, A, B, block_size) =
+choose_singlethread_parameter(C, A, B, block_size) =
     Singlethreaded(choose_block_size(C, A, B, block_size))
 
-function choose_parameter(::Type{Multithreaded}, C, A, B, ::Nothing, block_size)
+function choose_multithread_parameter(C, A, B, ::Nothing, block_size)
     m = Int128(size(A, 1))
     n = Int128(size(B, 1))
     k = Int128(size(A, 2))
@@ -19,12 +19,12 @@ function choose_parameter(::Type{Multithreaded}, C, A, B, ::Nothing, block_size)
     singlethread_size = cld(m * n * k, oversubscription_ratio * Threads.nthreads())
     return Multithreaded(
         singlethread_size,
-        choose_parameter(Singlethreaded, C, A, B, block_size),
+        choose_singlethread_parameter(C, A, B, block_size),
     )
 end
 
-choose_parameter(::Type{Multithreaded}, C, A, B, singlethread_size::Integer, block_size) =
-    Multithreaded(singlethread_size, choose_parameter(Singlethreaded, C, A, B, block_size))
+choose_multithread_parameter(C, A, B, singlethread_size::Integer, block_size) =
+    Multithreaded(singlethread_size, choose_singlethread_parameter(C, A, B, block_size))
 
 function use_singlethread(multithreaded::Multithreaded, C, A, B)
     m = Int128(size(A, 1))

--- a/src/choose_block_size.jl
+++ b/src/choose_block_size.jl
@@ -8,16 +8,23 @@ end
 
 choose_block_size(C, A, B, block_size::Integer) = block_size
 
-function choose_parameter(C, A, B, ::Nothing)
+choose_parameter(::Type{Singlethreaded}, C, A, B, block_size) =
+    Singlethreaded(choose_block_size(C, A, B, block_size))
+
+function choose_parameter(::Type{Multithreaded}, C, A, B, ::Nothing, block_size)
     m = Int128(size(A, 1))
     n = Int128(size(B, 1))
     k = Int128(size(A, 2))
     oversubscription_ratio = 8  # a magic constant that Works For Me
     singlethread_size = cld(m * n * k, oversubscription_ratio * Threads.nthreads())
-    return Multithreaded(singlethread_size)
+    return Multithreaded(
+        singlethread_size,
+        choose_parameter(Singlethreaded, C, A, B, block_size),
+    )
 end
 
-choose_parameter(C, A, B, singlethread_size::Integer) = Multithreaded(singlethread_size)
+choose_parameter(::Type{Multithreaded}, C, A, B, singlethread_size::Integer, block_size) =
+    Multithreaded(singlethread_size, choose_parameter(Singlethreaded, C, A, B, block_size))
 
 function use_singlethread(multithreaded::Multithreaded, C, A, B)
     m = Int128(size(A, 1))

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -1,76 +1,82 @@
-function _mul!(threading::Threading, C, A, B, sz)
+function _mul!(threading::Threading, C, A, B)
+    sz = get_block_size(threading)
     n, k, m = size(C, 1), size(A, 2), size(C, 2)
     if n >= sz+8 && m >= sz+8 && k >= sz+8
-        block_mat_mat_mul!(threading, C, A, B, sz)
+        block_mat_mat_mul!(threading, C, A, B)
     elseif n >= sz+8 && k >= sz+8 && m <  sz+8
-        block_mat_vec_mul!(threading, C, A, B, sz)
+        block_mat_vec_mul!(threading, C, A, B)
     elseif n <  sz+8 && k >= sz+8 && m >= sz+8
-        block_covec_mat_mul!(threading, C, A, B, sz)
+        block_covec_mat_mul!(threading, C, A, B)
     elseif n >= sz+8 && k <  sz+8 && m >= sz+8
-        block_vec_covec_mul!(threading, C, A, B, sz)
+        block_vec_covec_mul!(threading, C, A, B)
     elseif n <  sz+8 && k >= sz+8 && m <  sz+8
-        block_covec_vec_mul!(threading, C, A, B, sz)
+        block_covec_vec_mul!(threading, C, A, B)
     else
         gemm_kernel!(C, A, B)
     end
 end
 
-function _mul_add!(threading::Threading, C, A, B, sz, ::Val{factor} = Val(1)) where {factor}
+function _mul_add!(threading::Threading, C, A, B, ::Val{factor} = Val(1)) where {factor}
+    sz = get_block_size(threading)
     n, k, m = size(C, 1), size(A, 2), size(C, 2)
     if n >= sz+8 && m >= sz+8 && k >= sz+8
-        block_mat_mat_mul_add!(threading, C, A, B, sz, Val(factor))
+        block_mat_mat_mul_add!(threading, C, A, B, Val(factor))
     elseif n >= sz+8 && k >= sz+8 && m <  sz+8
-        block_mat_vec_mul_add!(threading, C, A, B, sz, Val(factor))
+        block_mat_vec_mul_add!(threading, C, A, B, Val(factor))
     elseif n <  sz+8 && k >= sz+8 && m >= sz+8
-        block_covec_mat_mul_add!(threading, C, A, B, sz, Val(factor))
+        block_covec_mat_mul_add!(threading, C, A, B, Val(factor))
     elseif n >= sz+8 && k <  sz+8 && m >= sz+8
-        block_vec_covec_mul_add!(threading, C, A, B, sz, Val(factor))
+        block_vec_covec_mul_add!(threading, C, A, B, Val(factor))
     elseif n <  sz+8 && k >= sz+8 && m <  sz+8
-        block_covec_vec_mul_add!(threading, C, A, B, sz, Val(factor))
+        block_covec_vec_mul_add!(threading, C, A, B, Val(factor))
     else
         add_gemm_kernel!(C, A, B, Val(factor))
     end
 end
 
-function _mul!(threading::Threading, C::VecTypes{T}, A::MatTypes{T}, B::VecTypes{T}, sz) where {T<:Eltypes}
+function _mul!(threading::Threading, C::VecTypes{T}, A::MatTypes{T}, B::VecTypes{T}) where {T<:Eltypes}
+    sz = get_block_size(threading)
     n, k = size(A)
     if     n >= sz+8 && k >= sz+8
-        block_mat_vec_mul!(threading, C, A, B, sz)
+        block_mat_vec_mul!(threading, C, A, B)
     elseif n <  sz+8 && k >= sz+8
-        block_covec_vec_mul!(threading, C, A, B, sz)
+        block_covec_vec_mul!(threading, C, A, B)
     else
         gemm_kernel!(C, A, B)
     end
 end
 
-function _mul_add!(threading::Threading, C::VecTypes{T}, A::MatTypes{T}, B::VecTypes{T}, sz, ::Val{factor} = Val(1)) where {factor, T<:Eltypes}
+function _mul_add!(threading::Threading, C::VecTypes{T}, A::MatTypes{T}, B::VecTypes{T}, ::Val{factor} = Val(1)) where {factor, T<:Eltypes}
+    sz = get_block_size(threading)
     n, k = size(A)
     if     n >= sz+8 && k >= sz+8
-        block_mat_vec_mul_add!(threading, C, A, B, sz, Val(factor))
+        block_mat_vec_mul_add!(threading, C, A, B, Val(factor))
     elseif n <  sz+8 && k >= sz+8
-        block_covec_vec_mul_add!(threading, C, A, B, sz, Val(factor))
+        block_covec_vec_mul_add!(threading, C, A, B, Val(factor))
     else
         add_gemm_kernel!(C, A, B, Val(factor))
     end
 end
 
-function _mul!(threading::Threading, C::CoVecTypes{T}, A::CoVecTypes{T}, B::MatTypes{T}, sz) where {T<:Eltypes}
+function _mul!(threading::Threading, C::CoVecTypes{T}, A::CoVecTypes{T}, B::MatTypes{T}) where {T<:Eltypes}
+    sz = get_block_size(threading)
     n, k, m = 1, size(A, 1), length(C)
     if     k >= sz+8 && m >= sz+8
-        block_covec_mat_mul!(threading, C, A, B, sz)
+        block_covec_mat_mul!(threading, C, A, B)
     elseif k >= sz+8 && m <  sz+8
-        block_covec_vec_mul!(threading, C, A, B, sz)
+        block_covec_vec_mul!(threading, C, A, B)
     else
         gemm_kernel!(C, A, B)
     end
 end
 
-function _mul_add!(threading::Threading, C::CoVecTypes{T}, A::CoVecTypes{T}, B::MatTypes{T}, sz, ::Val{factor} = Val(1)) where {factor, T<:Eltypes}
+function _mul_add!(threading::Threading, C::CoVecTypes{T}, A::CoVecTypes{T}, B::MatTypes{T}, ::Val{factor} = Val(1)) where {factor, T<:Eltypes}
+    sz = get_block_size(threading)
     n, k, m = 1, size(A, 1), length(C)
     if     k >= sz+8 && m >= sz+8
-        block_covec_mat_mul!(threading, C, A, B, sz, Val(factor))
+        block_covec_mat_mul!(threading, C, A, B, Val(factor))
     elseif k >= sz+8 && m <  sz+8
-        block_covec_vec_mul!(threading, C, A, B, sz, Val(factor))
+        block_covec_vec_mul!(threading, C, A, B, Val(factor))
     else
         add_gemm_kernel!(C, A, B, Val(factor))
     end

--- a/src/public_mul.jl
+++ b/src/public_mul.jl
@@ -79,7 +79,7 @@ function mul!(C::AbstractArray{T}, A::AbstractArray{T}, B::AbstractArray{T};
               sizecheck = true) where {T <: Eltypes}
     sizecheck && check_compatible_sizes(C, A, B)
 
-    multithreaded = choose_parameter(Multithreaded, C, A, B, singlethread_size, block_size)
+    multithreaded = choose_multithread_parameter(C, A, B, singlethread_size, block_size)
 
     _mul!(multithreaded, C, A, B)
     C
@@ -89,7 +89,7 @@ function mul_serial!(C::AbstractArray{T}, A::AbstractArray{T}, B::AbstractArray{
                               block_size = nothing, sizecheck=true) where {T <: Eltypes}
     sizecheck && check_compatible_sizes(C, A, B)
 
-    singlethreaded = choose_parameter(Singlethreaded, C, A, B, block_size)
+    singlethreaded = choose_singlethread_parameter(C, A, B, block_size)
 
     _mul!(singlethreaded, C, A, B)
     C
@@ -100,7 +100,7 @@ function mul!(C::StructArray{Complex{T}}, A::StructArray{Complex{T}}, B::StructA
               sizecheck = true) where {T <: Eltypes}
     sizecheck && check_compatible_sizes(C.re, A.re, B.re)
 
-    multithreaded = choose_parameter(Multithreaded, C, A, B, singlethread_size, block_size)
+    multithreaded = choose_multithread_parameter(C, A, B, singlethread_size, block_size)
 
     GC.@preserve C A B begin
         Cre, Cim = C.re, C.im
@@ -118,7 +118,7 @@ function mul_serial!(C::StructArray{Complex{T}}, A::StructArray{Complex{T}}, B::
                               block_size = default_block_size(), sizecheck=true) where {T <: Eltypes}
     sizecheck && check_compatible_sizes(C.re, A.re, B.re)
 
-    singlethreaded = choose_parameter(Singlethreaded, C, A, B, block_size)
+    singlethreaded = choose_singlethread_parameter(C, A, B, block_size)
 
     GC.@preserve C A B begin
         Cre, Cim = (C.re), (C.im)
@@ -139,7 +139,7 @@ function mul!(C::Adjoint{Complex{T}, <:StructArray{Complex{T}}},
               sizecheck = true) where {T <: Eltypes}
     sizecheck && check_compatible_sizes(C.parent.re', A.parent.re', B.re)
 
-    multithreaded = choose_parameter(Multithreaded, C, A, B, singlethread_size, block_size)
+    multithreaded = choose_multithread_parameter(C, A, B, singlethread_size, block_size)
     A.parent.im .= (-).(A.parent.im) #ugly hack
     GC.@preserve C A B begin
         Cre, Cim = (C.parent.re'), (C.parent.im')
@@ -161,7 +161,7 @@ function mul_serial!(C::Adjoint{Complex{T}, <:StructArray{Complex{T}}},
                               block_size = default_block_size(), sizecheck=true) where {T <: Eltypes}
     sizecheck && check_compatible_sizes(C.parent.re', A.parent.re', B.re)
 
-    singlethreaded = choose_parameter(Singlethreaded, C, A, B, block_size)
+    singlethreaded = choose_singlethread_parameter(C, A, B, block_size)
     A.parent.im .= (-).(A.parent.im) #ugly hack
     GC.@preserve C A B begin
         Cre, Cim = (C.parent.re'), (C.parent.im')
@@ -184,7 +184,7 @@ function mul!(C::Transpose{Complex{T}, <:StructArray{Complex{T}}},
               sizecheck = true) where {T <: Eltypes}
     sizecheck && check_compatible_sizes(C.parent.re |> transpose, A.parent.re |> transpose, B.re)
 
-    multithreaded = choose_parameter(Multithreaded, C, A, B, singlethread_size, block_size)
+    multithreaded = choose_multithread_parameter(C, A, B, singlethread_size, block_size)
 
     GC.@preserve C A B begin
         Cre, Cim = (C.parent.re |> transpose), (C.parent.im |> transpose)
@@ -204,7 +204,7 @@ function mul_serial!(C::Transpose{Complex{T}, <:StructArray{Complex{T}}},
                               block_size = default_block_size(), sizecheck=true) where {T <: Eltypes}
     sizecheck && check_compatible_sizes(C.parent.re |> transpose, A.parent.re |> transpose, B.re)
 
-    singlethreaded = choose_parameter(Singlethreaded, C, A, B, block_size)
+    singlethreaded = choose_singlethread_parameter(C, A, B, block_size)
 
     GC.@preserve C A B begin
         Cre, Cim = (C.parent.re |> transpose), (C.parent.im |> transpose)

--- a/src/public_mul.jl
+++ b/src/public_mul.jl
@@ -79,10 +79,9 @@ function mul!(C::AbstractArray{T}, A::AbstractArray{T}, B::AbstractArray{T};
               sizecheck = true) where {T <: Eltypes}
     sizecheck && check_compatible_sizes(C, A, B)
 
-    _block_size = choose_block_size(C, A, B, block_size)
-    multithreaded = choose_parameter(C, A, B, singlethread_size)
+    multithreaded = choose_parameter(Multithreaded, C, A, B, singlethread_size, block_size)
 
-    _mul!(multithreaded, C, A, B, _block_size)
+    _mul!(multithreaded, C, A, B)
     C
 end
 
@@ -90,9 +89,9 @@ function mul_serial!(C::AbstractArray{T}, A::AbstractArray{T}, B::AbstractArray{
                               block_size = nothing, sizecheck=true) where {T <: Eltypes}
     sizecheck && check_compatible_sizes(C, A, B)
 
-    _block_size = choose_block_size(C, A, B, block_size)
+    singlethreaded = choose_parameter(Singlethreaded, C, A, B, block_size)
 
-    _mul!(singlethreaded, C, A, B, _block_size)
+    _mul!(singlethreaded, C, A, B)
     C
 end
 
@@ -101,17 +100,16 @@ function mul!(C::StructArray{Complex{T}}, A::StructArray{Complex{T}}, B::StructA
               sizecheck = true) where {T <: Eltypes}
     sizecheck && check_compatible_sizes(C.re, A.re, B.re)
 
-    _block_size = choose_block_size(C, A, B, block_size)
-    multithreaded = choose_parameter(C, A, B, singlethread_size)
+    multithreaded = choose_parameter(Multithreaded, C, A, B, singlethread_size, block_size)
 
     GC.@preserve C A B begin
         Cre, Cim = C.re, C.im
         Are, Aim = A.re, A.im
         Bre, Bim = B.re, B.im
-        _mul!(    multithreaded,     Cre, Are, Bre, _block_size)          # C.re = A.re * B.re
-        _mul_add!(multithreaded,     Cre, Aim, Bim, _block_size, Val(-1)) # C.re = C.re - A.im * B.im
-        _mul!(    multithreaded,     Cim, Are, Bim, _block_size)          # C.im = A.re * B.im
-        _mul_add!(multithreaded,     Cim, Aim, Bre, _block_size)          # C.im = C.im + A.im * B.re
+        _mul!(    multithreaded,     Cre, Are, Bre)          # C.re = A.re * B.re
+        _mul_add!(multithreaded,     Cre, Aim, Bim, Val(-1)) # C.re = C.re - A.im * B.im
+        _mul!(    multithreaded,     Cim, Are, Bim)          # C.im = A.re * B.im
+        _mul_add!(multithreaded,     Cim, Aim, Bre)          # C.im = C.im + A.im * B.re
     end
     C
 end
@@ -120,16 +118,16 @@ function mul_serial!(C::StructArray{Complex{T}}, A::StructArray{Complex{T}}, B::
                               block_size = default_block_size(), sizecheck=true) where {T <: Eltypes}
     sizecheck && check_compatible_sizes(C.re, A.re, B.re)
 
-    _block_size = choose_block_size(C, A, B, block_size)
+    singlethreaded = choose_parameter(Singlethreaded, C, A, B, block_size)
 
     GC.@preserve C A B begin
         Cre, Cim = (C.re), (C.im)
         Are, Aim = (A.re), (A.im)
         Bre, Bim = (B.re), (B.im)
-        _mul!(    singlethreaded,     Cre, Are, Bre, _block_size)          # C.re = A.re * B.re
-        _mul_add!(singlethreaded,     Cre, Aim, Bim, _block_size, Val(-1)) # C.re = C.re - A.im * B.im
-        _mul!(    singlethreaded,     Cim, Are, Bim, _block_size)          # C.im = A.re * B.im
-        _mul_add!(singlethreaded,     Cim, Aim, Bre, _block_size)          # C.im = C.im + A.im * B.re
+        _mul!(    singlethreaded,     Cre, Are, Bre)          # C.re = A.re * B.re
+        _mul_add!(singlethreaded,     Cre, Aim, Bim, Val(-1)) # C.re = C.re - A.im * B.im
+        _mul!(    singlethreaded,     Cim, Are, Bim)          # C.im = A.re * B.im
+        _mul_add!(singlethreaded,     Cim, Aim, Bre)          # C.im = C.im + A.im * B.re
     end
     C
 end
@@ -141,17 +139,16 @@ function mul!(C::Adjoint{Complex{T}, <:StructArray{Complex{T}}},
               sizecheck = true) where {T <: Eltypes}
     sizecheck && check_compatible_sizes(C.parent.re', A.parent.re', B.re)
 
-    _block_size = choose_block_size(C, A, B, block_size)
-    multithreaded = choose_parameter(C, A, B, singlethread_size)
+    multithreaded = choose_parameter(Multithreaded, C, A, B, singlethread_size, block_size)
     A.parent.im .= (-).(A.parent.im) #ugly hack
     GC.@preserve C A B begin
         Cre, Cim = (C.parent.re'), (C.parent.im')
         Are, Aim = (A.parent.re'), (A.parent.im')
         Bre, Bim = (B.re), (B.im)
-        _mul!(    multithreaded,     Cre, Are, Bre, _block_size)          # C.re = A.re * B.re
-        _mul_add!(multithreaded,     Cre, Aim, Bim, _block_size, Val(-1)) # C.re = C.re - A.im * B.im
-        _mul!(    multithreaded,     Cim, Are, Bim, _block_size)          # C.im = A.re * B.im
-        _mul_add!(multithreaded,     Cim, Aim, Bre, _block_size)          # C.im = C.im + A.im * B.re
+        _mul!(    multithreaded,     Cre, Are, Bre)          # C.re = A.re * B.re
+        _mul_add!(multithreaded,     Cre, Aim, Bim, Val(-1)) # C.re = C.re - A.im * B.im
+        _mul!(    multithreaded,     Cim, Are, Bim)          # C.im = A.re * B.im
+        _mul_add!(multithreaded,     Cim, Aim, Bre)          # C.im = C.im + A.im * B.re
     end
     A.parent.im .= (-).(A.parent.im)
     C.parent.im .= (-).(C.parent.im) # ugly hack
@@ -164,16 +161,16 @@ function mul_serial!(C::Adjoint{Complex{T}, <:StructArray{Complex{T}}},
                               block_size = default_block_size(), sizecheck=true) where {T <: Eltypes}
     sizecheck && check_compatible_sizes(C.parent.re', A.parent.re', B.re)
 
-    _block_size = choose_block_size(C, A, B, block_size)
+    singlethreaded = choose_parameter(Singlethreaded, C, A, B, block_size)
     A.parent.im .= (-).(A.parent.im) #ugly hack
     GC.@preserve C A B begin
         Cre, Cim = (C.parent.re'), (C.parent.im')
         Are, Aim = (A.parent.re'), (A.parent.im')
         Bre, Bim = (B.re), (B.im)
-        _mul!(    singlethreaded,     Cre, Are, Bre, _block_size)          # C.re = A.re * B.re
-        _mul_add!(singlethreaded,     Cre, Aim, Bim, _block_size, Val(-1)) # C.re = C.re - A.im * B.im
-        _mul!(    singlethreaded,     Cim, Are, Bim, _block_size)          # C.im = A.re * B.im
-        _mul_add!(singlethreaded,     Cim, Aim, Bre, _block_size)          # C.im = C.im + A.im * B.re
+        _mul!(    singlethreaded,     Cre, Are, Bre)          # C.re = A.re * B.re
+        _mul_add!(singlethreaded,     Cre, Aim, Bim, Val(-1)) # C.re = C.re - A.im * B.im
+        _mul!(    singlethreaded,     Cim, Are, Bim)          # C.im = A.re * B.im
+        _mul_add!(singlethreaded,     Cim, Aim, Bre)          # C.im = C.im + A.im * B.re
     end
     A.parent.im .= (-).(A.parent.im)
     C.parent.im .= (-).(C.parent.im) # ugly hack
@@ -187,17 +184,16 @@ function mul!(C::Transpose{Complex{T}, <:StructArray{Complex{T}}},
               sizecheck = true) where {T <: Eltypes}
     sizecheck && check_compatible_sizes(C.parent.re |> transpose, A.parent.re |> transpose, B.re)
 
-    _block_size = choose_block_size(C, A, B, block_size)
-    multithreaded = choose_parameter(C, A, B, singlethread_size)
+    multithreaded = choose_parameter(Multithreaded, C, A, B, singlethread_size, block_size)
 
     GC.@preserve C A B begin
         Cre, Cim = (C.parent.re |> transpose), (C.parent.im |> transpose)
         Are, Aim = (A.parent.re |> transpose), (A.parent.im |> transpose)
         Bre, Bim = (B.re), (B.im)
-        _mul!(    multithreaded,     Cre, Are, Bre, _block_size)          # C.re = A.re * B.re
-        _mul_add!(multithreaded,     Cre, Aim, Bim, _block_size, Val(-1)) # C.re = C.re - A.im * B.im
-        _mul!(    multithreaded,     Cim, Are, Bim, _block_size)          # C.im = A.re * B.im
-        _mul_add!(multithreaded,     Cim, Aim, Bre, _block_size)          # C.im = C.im + A.im * B.re
+        _mul!(    multithreaded,     Cre, Are, Bre)          # C.re = A.re * B.re
+        _mul_add!(multithreaded,     Cre, Aim, Bim, Val(-1)) # C.re = C.re - A.im * B.im
+        _mul!(    multithreaded,     Cim, Are, Bim)          # C.im = A.re * B.im
+        _mul_add!(multithreaded,     Cim, Aim, Bre)          # C.im = C.im + A.im * B.re
     end
     C
 end
@@ -208,16 +204,16 @@ function mul_serial!(C::Transpose{Complex{T}, <:StructArray{Complex{T}}},
                               block_size = default_block_size(), sizecheck=true) where {T <: Eltypes}
     sizecheck && check_compatible_sizes(C.parent.re |> transpose, A.parent.re |> transpose, B.re)
 
-    _block_size = choose_block_size(C, A, B, block_size)
+    singlethreaded = choose_parameter(Singlethreaded, C, A, B, block_size)
 
     GC.@preserve C A B begin
         Cre, Cim = (C.parent.re |> transpose), (C.parent.im |> transpose)
         Are, Aim = (A.parent.re |> transpose), (A.parent.im |> transpose)
         Bre, Bim = (B.re), (B.im)
-        _mul!(    singlethreaded,     Cre, Are, Bre, _block_size)          # C.re = A.re * B.re
-        _mul_add!(singlethreaded,     Cre, Aim, Bim, _block_size, Val(-1)) # C.re = C.re - A.im * B.im
-        _mul!(    singlethreaded,     Cim, Are, Bim, _block_size)          # C.im = A.re * B.im
-        _mul_add!(singlethreaded,     Cim, Aim, Bre, _block_size)          # C.im = C.im + A.im * B.re
+        _mul!(    singlethreaded,     Cre, Are, Bre)          # C.re = A.re * B.re
+        _mul_add!(singlethreaded,     Cre, Aim, Bim, Val(-1)) # C.re = C.re - A.im * B.im
+        _mul!(    singlethreaded,     Cim, Are, Bim)          # C.im = A.re * B.im
+        _mul_add!(singlethreaded,     Cim, Aim, Bre)          # C.im = C.im + A.im * B.re
     end
     C
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -11,12 +11,14 @@ const CoVecTypes{T} = Union{Adjoint{T,   <:VecTypes{T}},
 
 abstract type Threading end
 
+struct Singlethreaded <: Threading
+    block_size::Int64
+end
+
 struct Multithreaded <: Threading
     singlethread_size::Int64
-    # TODO: Add `block_size`
+    singlethreaded::Singlethreaded
 end
 
-struct Singlethreaded <: Threading
-end
-
-const singlethreaded = Singlethreaded()
+get_block_size(singlethreaded::Singlethreaded) = singlethreaded.block_size
+get_block_size(multithreaded::Multithreaded) = get_block_size(multithreaded.singlethreaded)

--- a/test/_matmul.jl
+++ b/test/_matmul.jl
@@ -6,9 +6,10 @@
 # `m_values`
 
 @time @testset "_mul!: C, A, B $(testset_name_suffix)" begin
-    multithreaded = Gaius.Multithreaded(2^24)
-    for threading in [Gaius.singlethreaded, multithreaded]
-        for sz in sz_values
+    for sz in sz_values
+        singlethreaded = Gaius.Singlethreaded(sz)
+        multithreaded = Gaius.Multithreaded(2^24, singlethreaded)
+        for threading in [singlethreaded, multithreaded]
             for n in n_values
                 for k in k_values
                     for m in m_values
@@ -16,8 +17,8 @@
                         B = randn(Float64, k, m)
                         C1 = zeros(Float64, n, m)
                         C2 = zeros(Float64, n, m)
-                        Gaius._mul!(    threading, C1, A, B, sz)
-                        Gaius._mul_add!(threading, C2, A, B, sz, Val(1))
+                        Gaius._mul!(    threading, C1, A, B)
+                        Gaius._mul_add!(threading, C2, A, B, Val(1))
                         @test A * B ≈ C1
                         @test A * B ≈ C2
                     end
@@ -28,9 +29,10 @@
 end
 
 @time @testset "_mul!: C::VecTypes, A::MatTypes, B::VecTypes $(testset_name_suffix)" begin
-    multithreaded = Gaius.Multithreaded(2^24)
-    for threading in [Gaius.singlethreaded, multithreaded]
-        for sz in sz_values
+    for sz in sz_values
+        singlethreaded = Gaius.Singlethreaded(sz)
+        multithreaded = Gaius.Multithreaded(2^24, singlethreaded)
+        for threading in [singlethreaded, multithreaded]
             for n in n_values
                 for k in k_values
                     for m in m_values
@@ -38,8 +40,8 @@ end
                         B = randn(Float64, k)
                         C1 = zeros(Float64, n)
                         C2 = zeros(Float64, n)
-                        Gaius._mul!(    threading, C1, A, B, sz)
-                        Gaius._mul_add!(threading, C2, A, B, sz, Val(1))
+                        Gaius._mul!(    threading, C1, A, B)
+                        Gaius._mul_add!(threading, C2, A, B, Val(1))
                         @test A * B ≈ C1
                         @test A * B ≈ C2
                     end
@@ -50,9 +52,10 @@ end
 end
 
 @time @testset "_mul!: C::CoVecTypes, A::CoVecTypes, B::MatTypes $(testset_name_suffix)" begin
-    multithreaded = Gaius.Multithreaded(2^24)
-    for threading in [Gaius.singlethreaded, multithreaded]
-        for sz in sz_values
+    for sz in sz_values
+        singlethreaded = Gaius.Singlethreaded(sz)
+        multithreaded = Gaius.Multithreaded(2^24, singlethreaded)
+        for threading in [singlethreaded, multithreaded]
             for n in n_values
                 for k in k_values
                     for m in m_values
@@ -60,8 +63,8 @@ end
                         B = randn(Float64, n, m)
                         C1 = adjoint(zeros(Float64, m))
                         C2 = adjoint(zeros(Float64, m))
-                        Gaius._mul!(    threading, C1, A, B, sz)
-                        Gaius._mul_add!(threading, C2, A, B, sz, Val(1))
+                        Gaius._mul!(    threading, C1, A, B)
+                        Gaius._mul_add!(threading, C2, A, B, Val(1))
                         @test A * B ≈ C1
                         @test A * B ≈ C2
                     end

--- a/test/block_operations.jl
+++ b/test/block_operations.jl
@@ -1,10 +1,10 @@
 @time @testset "block_operations" begin
-    multithreaded = Gaius.Multithreaded(0)
+    multithreaded = Gaius.Multithreaded(0, Gaius.Singlethreaded(1))
     @testset begin
         A = [1 2; 3 4]
         B = [5 6; 7 8]
         C = Matrix{Int}(undef, 2, 2)
-        Gaius.block_covec_vec_mul!(multithreaded, C, A, B, 1)
+        Gaius.block_covec_vec_mul!(multithreaded, C, A, B)
         @test C == A * B
     end
 
@@ -12,7 +12,7 @@
         A = [1 2; 3 4]
         B = [5, 6]
         C = Vector{Int}(undef, 2)
-        Gaius.block_covec_vec_mul!(multithreaded, C, A, B, 1)
+        Gaius.block_covec_vec_mul!(multithreaded, C, A, B)
         @test C == A * B
     end
 end


### PR DESCRIPTION
This is a simple refactoring I suggested in #88. `block_size` is now in `Singlethreaded`; i.e., I suggest changing

https://github.com/MasonProtter/Gaius.jl/blob/05ad6fdd5f7b15d2839a845eddfafb36d253e262/src/types.jl#L14-L20

to

https://github.com/MasonProtter/Gaius.jl/blob/c893df82c7ae0981303139c56d783c8af1fdeabc/src/types.jl#L14-L21

This simplifies the signature of the recursive functions. For example

https://github.com/MasonProtter/Gaius.jl/blob/c893df82c7ae0981303139c56d783c8af1fdeabc/src/block_operations.jl#L1

does not have the block size `sz` argument anymore.